### PR TITLE
fix: add nil checks to BinarySource methods

### DIFF
--- a/internal/domain/binary_source.go
+++ b/internal/domain/binary_source.go
@@ -99,6 +99,10 @@ func NewBinarySource(sourceType SourceType) *BinarySource {
 // Note: This method validates the domain entity state, not the actual binary file.
 // Binary file validation (executable check, architecture check) is done by infrastructure layer.
 func (b *BinarySource) Validate() error {
+	if b == nil {
+		return fmt.Errorf("binary source is nil")
+	}
+
 	// Rule 1: SourceType == Local requires SelectedPath
 	if b.SourceType == SourceTypeLocal && b.SelectedPath == "" {
 		return fmt.Errorf("local binary source requires a selected path")
@@ -119,17 +123,25 @@ func (b *BinarySource) Validate() error {
 
 // MarkValid marks the binary source as validated successfully.
 // This should be called after infrastructure layer verifies the binary file.
+// No-op if the receiver is nil.
 func (b *BinarySource) MarkValid() {
+	if b == nil {
+		return
+	}
 	b.ValidationStatus = true
 	b.ValidationError = ""
 }
 
 // MarkInvalid marks the binary source as invalid with the given error message.
 // This should be called when infrastructure layer validation fails.
+// No-op if the receiver is nil.
 //
 // Parameters:
 //   - err: The validation error that occurred
 func (b *BinarySource) MarkInvalid(err error) {
+	if b == nil {
+		return
+	}
 	b.ValidationStatus = false
 	if err != nil {
 		b.ValidationError = err.Error()
@@ -137,20 +149,32 @@ func (b *BinarySource) MarkInvalid(err error) {
 }
 
 // IsValid returns true if the binary source has been validated successfully.
+// Returns false if the receiver is nil.
 //
 // Returns:
 //   - bool: true if ValidationStatus is true and ValidationError is empty
 func (b *BinarySource) IsValid() bool {
+	if b == nil {
+		return false
+	}
 	return b.ValidationStatus && b.ValidationError == ""
 }
 
 // IsLocal returns true if this is a local filesystem binary source.
+// Returns false if the receiver is nil.
 func (b *BinarySource) IsLocal() bool {
+	if b == nil {
+		return false
+	}
 	return b.SourceType == SourceTypeLocal
 }
 
 // IsGitHubRelease returns true if this is a GitHub release binary source.
+// Returns false if the receiver is nil.
 func (b *BinarySource) IsGitHubRelease() bool {
+	if b == nil {
+		return false
+	}
 	return b.SourceType == SourceTypeGitHubRelease
 }
 

--- a/internal/domain/binary_source_nil_test.go
+++ b/internal/domain/binary_source_nil_test.go
@@ -1,0 +1,37 @@
+package domain
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestBinarySourceNilSafety(t *testing.T) {
+	var nilSource *BinarySource
+
+	// Test IsLocal on nil
+	if nilSource.IsLocal() {
+		t.Error("IsLocal() on nil should return false")
+	}
+
+	// Test IsGitHubRelease on nil
+	if nilSource.IsGitHubRelease() {
+		t.Error("IsGitHubRelease() on nil should return false")
+	}
+
+	// Test IsValid on nil
+	if nilSource.IsValid() {
+		t.Error("IsValid() on nil should return false")
+	}
+
+	// Test MarkValid on nil (should not panic)
+	nilSource.MarkValid()
+
+	// Test MarkInvalid on nil (should not panic)
+	nilSource.MarkInvalid(fmt.Errorf("test error"))
+
+	// Test Validate on nil
+	err := nilSource.Validate()
+	if err == nil {
+		t.Error("Validate() on nil should return an error")
+	}
+}


### PR DESCRIPTION
## Summary

- Add nil receiver checks to `BinarySource` methods to prevent SIGSEGV panic
- `IsLocal()`, `IsGitHubRelease()`, `IsValid()` return `false` when nil
- `MarkValid()`, `MarkInvalid()` are no-ops when nil
- `Validate()` returns descriptive error when nil

## Problem

The upgrade command panics with nil pointer dereference at `binary_source.go:149` when `BinarySource` is nil:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x133c300]

goroutine 1 [running]:
github.com/altuslabsxyz/devnet-builder/internal/domain.(*BinarySource).IsLocal(0x1da21a0?)
        /home/ubuntu/devnet-builder/internal/domain/binary_source.go:149
github.com/altuslabsxyz/devnet-builder/cmd/devnet-builder/commands/manage.runUpgrade(...)
        /home/ubuntu/devnet-builder/cmd/devnet-builder/commands/manage/upgrade.go:294
```

## Root Cause

At `upgrade.go:294`, `selection.BinarySource.IsLocal()` is called without nil check. The interactive selection can return nil `BinarySource` in certain flows.

## Test plan

- [x] Added unit test `TestBinarySourceNilSafety` verifying all methods handle nil safely
- [x] `go build ./...` passes
- [x] `go test ./internal/domain/...` passes