### PR TITLE
fix: replace invalid BIP-39 test mnemonic

### DIFF
--- a/internal/infrastructure/nodeconfig/initializer.go
+++ b/internal/infrastructure/nodeconfig/initializer.go
@@ -403,8 +403,8 @@ var TestMnemonics = []string{
 	"myth like bonus scare over problem client lizard pioneer submit female collect",
 	// Account 0 - BIP-39 test vector (letter = abandon but with variety)
 	"letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
-	// Account 1 - Foundry/Anvil default mnemonic
-	"body quick review slot oblige virus address analyst much half royal canvas",
+	// Account 1 - BIP-39 test vector (entropy: 000102030405060708090a0b0c0d0e0f)
+	"abandon amount liar amount expire adjust cage candy arch gather drum buyer",
 	// Account 2 - Standard test vector
 	"void come effort suffer camp survey warrior heavy shoot primary clutch crush",
 	// Account 3 - Another standard test vector


### PR DESCRIPTION
## Summary
- Fixed invalid BIP-39 mnemonic at index 5 in TestMnemonics
- The mnemonic `body quick review slot oblige virus address analyst much half royal canvas` had an invalid checksum
- Replaced with official BIP-39 test vector: `abandon amount liar amount expire adjust cage candy arch gather drum buyer`

## Problem
`devnet-builder deploy` failed with "Invalid mnenomic" when creating additional account keys because the mnemonic at index 5 was not a valid BIP-39 mnemonic.

## Test plan
- [ ] Run `devnet-builder deploy` and verify additional account keys are created successfully