### PR TITLE
fix: version selection uses correct blockchain repo

### DIFF
--- a/cmd/devnet-builder/commands/manage/deploy.go
+++ b/cmd/devnet-builder/commands/manage/deploy.go
@@ -252,7 +252,8 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		if isInteractive {
 			// includeNetworkSelection = false (network is already known from config)
 			// Pass deployNetwork so ConfirmSelection shows the correct network
-			selection, err := RunInteractiveVersionSelection(ctx, cmd, false, deployNetwork)
+			// Pass deployBlockchainNetwork to fetch releases from the correct repository
+			selection, err := RunInteractiveVersionSelection(ctx, cmd, false, deployNetwork, deployBlockchainNetwork)
 			if err != nil {
 				return WrapInteractiveError(cmd, err, "failed during interactive selection")
 			}

--- a/cmd/devnet-builder/commands/manage/upgrade.go
+++ b/cmd/devnet-builder/commands/manage/upgrade.go
@@ -295,7 +295,8 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 		// forUpgrade = true: collects only upgrade target version (no export/start distinction)
 		// includeNetworkSelection = false: network is already determined from running devnet
 		// skipUpgradeName = skipGovernance: skip upgrade name prompt when --skip-gov is set
-		selection, err := RunInteractiveVersionSelectionWithMode(ctx, cmd, false, true, "", skipGovernance)
+		// Pass cleanMetadata.BlockchainNetwork to fetch releases from the correct repository
+		selection, err := RunInteractiveVersionSelectionWithMode(ctx, cmd, false, true, "", skipGovernance, cleanMetadata.BlockchainNetwork)
 		if err != nil {
 			if interactive.IsCancellation(err) {
 				fmt.Println("Operation cancelled.")


### PR DESCRIPTION
## Summary
- Fixed TTY detection to check stdin instead of stdout for promptui compatibility
- Fixed GitHub client to use blockchain-specific repository based on config

## Changes
- `source_selector.go`, `binary_selector.go`: Check `os.Stdin.Fd()` for TTY detection
- `shared.go`: Added `blockchainNetwork` param to `SetupGitHubClient`, uses `network.Get()` to resolve correct owner/repo
- `deploy.go`, `upgrade.go`: Pass blockchain network to version selection functions

## Test plan
- [ ] Run `devnet-builder deploy` with `blockchain_network = "ault"` - should show ault releases
- [ ] Run `devnet-builder deploy` with `blockchain_network = "stable"` - should show stable releases
- [ ] Run `devnet-builder upgrade` - should use blockchain network from running devnet