### PR TITLE
ci: optimize workflow with path-based conditional jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 # Continuous Integration Workflow
-# Runs tests, linting, and build checks on all code changes
+# Runs tests, linting, and build checks on code changes
+# Optimized to skip jobs when only irrelevant files change
 
 name: CI
 
@@ -28,10 +29,47 @@ env:
   GOWORK: off
 
 jobs:
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      go-changed: ${{ steps.changes.outputs.go }}
+      proto-changed: ${{ steps.changes.outputs.proto }}
+      ci-changed: ${{ steps.changes.outputs.ci }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect file changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            go:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+            proto:
+              - 'api/proto/**'
+              - 'buf.yaml'
+              - 'buf.gen.yaml'
+            ci:
+              - '.github/workflows/ci.yml'
+              - '.golangci.yml'
+
   build:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: detect-changes
+    if: |
+      needs.detect-changes.outputs.go-changed == 'true' ||
+      needs.detect-changes.outputs.ci-changed == 'true'
 
     steps:
       - name: Checkout code
@@ -53,6 +91,10 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: detect-changes
+    if: |
+      needs.detect-changes.outputs.go-changed == 'true' ||
+      needs.detect-changes.outputs.ci-changed == 'true'
 
     steps:
       - name: Checkout code
@@ -74,6 +116,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: detect-changes
+    if: |
+      needs.detect-changes.outputs.go-changed == 'true' ||
+      needs.detect-changes.outputs.ci-changed == 'true'
 
     steps:
       - name: Checkout code
@@ -99,12 +145,16 @@ jobs:
     name: Proto
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: detect-changes
+    if: |
+      needs.detect-changes.outputs.proto-changed == 'true' ||
+      needs.detect-changes.outputs.ci-changed == 'true'
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Needed for breaking change detection
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -140,19 +190,36 @@ jobs:
   ci-complete:
     name: CI Complete
     runs-on: ubuntu-latest
-    needs: [build, test, lint, proto]
+    needs: [detect-changes, build, test, lint, proto]
     if: always()
 
     steps:
       - name: Check results
         env:
+          CHANGES_RESULT: ${{ needs.detect-changes.result }}
           BUILD_RESULT: ${{ needs.build.result }}
           TEST_RESULT: ${{ needs.test.result }}
           LINT_RESULT: ${{ needs.lint.result }}
           PROTO_RESULT: ${{ needs.proto.result }}
         run: |
-          if [ "$BUILD_RESULT" == "failure" ] || [ "$TEST_RESULT" == "failure" ] || [ "$LINT_RESULT" == "failure" ] || [ "$PROTO_RESULT" == "failure" ]; then
-            echo "CI failed"
+          echo "Detection: $CHANGES_RESULT"
+          echo "Build: $BUILD_RESULT"
+          echo "Test: $TEST_RESULT"
+          echo "Lint: $LINT_RESULT"
+          echo "Proto: $PROTO_RESULT"
+
+          # Fail if detection failed
+          if [ "$CHANGES_RESULT" == "failure" ]; then
+            echo "::error::Change detection failed"
             exit 1
           fi
-          echo "CI passed"
+
+          # Check each job - 'skipped' is acceptable, 'failure' is not
+          for result in "$BUILD_RESULT" "$TEST_RESULT" "$LINT_RESULT" "$PROTO_RESULT"; do
+            if [ "$result" == "failure" ]; then
+              echo "::error::CI failed"
+              exit 1
+            fi
+          done
+
+          echo "✅ CI passed (some jobs may have been skipped based on changes)"


### PR DESCRIPTION
## Summary

- Add change detection job using dorny/paths-filter
- Build/test/lint only run when Go or CI files change
- Proto job only runs when proto or CI files change
- Skip all jobs for docs-only changes
- Properly handle skipped jobs in ci-complete

## Expected Savings

| Change Type | Jobs Before | Jobs After |
|-------------|-------------|------------|
| Docs only   | 4 jobs      | 1 job      |
| Proto only  | 4 jobs      | 2 jobs     |
| Go code     | 4 jobs      | 5 jobs     |

Reduces GitHub Actions minutes by 50-70% for non-code changes.