### PR TITLE
fix: use space-separated go build tags

### DIFF
--- a/internal/plugin/cosmos/builder.go
+++ b/internal/plugin/cosmos/builder.go
@@ -46,7 +46,7 @@ func (b *CosmosBuilder) DefaultBuildFlags() map[string]string {
 			"-X github.com/cosmos/cosmos-sdk/version.AppName={{.BinaryName}} " +
 			"-X github.com/cosmos/cosmos-sdk/version.Version={{.GitRef}} " +
 			"-X github.com/cosmos/cosmos-sdk/version.Commit={{.GitCommit}}",
-		"tags": "netgo,ledger",
+		"tags": "netgo ledger",
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fix Go build tags format from comma-separated to space-separated

The `go install -tags` flag requires space-separated tags, not comma-separated. This was causing build failures with:
```
go: -tags space-separated list contains comma
```

## Changes
- Changed `"netgo,ledger"` to `"netgo ledger"` in `CosmosBuilder.DefaultBuildFlags()`

## Test plan
- [x] All unit tests pass
- [x] Verified no other comma-separated tags in codebase