### PR TITLE
fix: use store.IsNotFound() to prevent infinite reconcile loop on deletion

### DIFF
--- a/internal/daemon/controller/devnet.go
+++ b/internal/daemon/controller/devnet.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -73,7 +72,7 @@ func (c *DevnetController) Reconcile(ctx context.Context, key string) error {
 	// Get the devnet from store
 	devnet, err := c.store.GetDevnet(ctx, namespace, name)
 	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
+		if store.IsNotFound(err) {
 			// Devnet was deleted, nothing to do
 			c.logger.Debug("devnet not found (deleted?)", "key", key)
 			return nil

--- a/internal/daemon/server/devnet_service.go
+++ b/internal/daemon/server/devnet_service.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 	"time"
 
@@ -57,7 +56,7 @@ func (s *DevnetService) CreateDevnet(ctx context.Context, req *v1.CreateDevnetRe
 	// Store it
 	err := s.store.CreateDevnet(ctx, devnet)
 	if err != nil {
-		if errors.Is(err, store.ErrAlreadyExists) {
+		if store.IsAlreadyExists(err) {
 			return nil, status.Errorf(codes.AlreadyExists, "devnet %q already exists", req.Name)
 		}
 		s.logger.Error("failed to create devnet", "name", req.Name, "error", err)
@@ -83,7 +82,7 @@ func (s *DevnetService) GetDevnet(ctx context.Context, req *v1.GetDevnetRequest)
 
 	devnet, err := s.store.GetDevnet(ctx, namespace, req.Name)
 	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
+		if store.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "devnet %q not found", req.Name)
 		}
 		s.logger.Error("failed to get devnet", "name", req.Name, "error", err)
@@ -149,7 +148,7 @@ func (s *DevnetService) DeleteDevnet(ctx context.Context, req *v1.DeleteDevnetRe
 
 	err := s.store.DeleteDevnet(ctx, namespace, req.Name)
 	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
+		if store.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "devnet %q not found", req.Name)
 		}
 		s.logger.Error("failed to delete devnet", "name", req.Name, "error", err)
@@ -180,7 +179,7 @@ func (s *DevnetService) StartDevnet(ctx context.Context, req *v1.StartDevnetRequ
 
 	devnet, err := s.store.GetDevnet(ctx, namespace, req.Name)
 	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
+		if store.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "devnet %q not found", req.Name)
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get devnet: %v", err)
@@ -221,7 +220,7 @@ func (s *DevnetService) StopDevnet(ctx context.Context, req *v1.StopDevnetReques
 
 	devnet, err := s.store.GetDevnet(ctx, namespace, req.Name)
 	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
+		if store.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "devnet %q not found", req.Name)
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get devnet: %v", err)
@@ -262,7 +261,7 @@ func (s *DevnetService) ApplyDevnet(ctx context.Context, req *v1.ApplyDevnetRequ
 
 	// Check if devnet exists
 	existing, err := s.store.GetDevnet(ctx, namespace, req.Name)
-	if err != nil && !errors.Is(err, store.ErrNotFound) {
+	if err != nil && !store.IsNotFound(err) {
 		s.logger.Error("failed to get devnet", "namespace", namespace, "name", req.Name, "error", err)
 		return nil, status.Errorf(codes.Internal, "failed to get devnet: %v", err)
 	}
@@ -340,7 +339,7 @@ func (s *DevnetService) UpdateDevnet(ctx context.Context, req *v1.UpdateDevnetRe
 
 	existing, err := s.store.GetDevnet(ctx, namespace, req.Name)
 	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
+		if store.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "devnet %q not found in namespace %q", req.Name, namespace)
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get devnet: %v", err)

--- a/internal/daemon/server/transaction_service.go
+++ b/internal/daemon/server/transaction_service.go
@@ -4,7 +4,6 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -99,7 +98,7 @@ func (s *TransactionService) GetTransaction(ctx context.Context, req *v1.GetTran
 
 	tx, err := s.store.GetTransaction(ctx, req.Name)
 	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
+		if store.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "transaction %s not found", req.Name)
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get transaction: %v", err)
@@ -144,7 +143,7 @@ func (s *TransactionService) CancelTransaction(ctx context.Context, req *v1.Canc
 
 	tx, err := s.store.GetTransaction(ctx, req.Name)
 	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
+		if store.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "transaction %s not found", req.Name)
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get transaction: %v", err)

--- a/internal/daemon/server/upgrade_service.go
+++ b/internal/daemon/server/upgrade_service.go
@@ -3,7 +3,6 @@ package server
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 
 	v1 "github.com/altuslabsxyz/devnet-builder/api/proto/gen/v1"
@@ -67,7 +66,7 @@ func (s *UpgradeService) CreateUpgrade(ctx context.Context, req *v1.CreateUpgrad
 	// Verify devnet exists
 	_, err := s.store.GetDevnet(ctx, namespace, req.Spec.DevnetRef)
 	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
+		if store.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "devnet %q not found", req.Spec.DevnetRef)
 		}
 		s.logger.Error("failed to get devnet", "devnet", req.Spec.DevnetRef, "error", err)
@@ -80,7 +79,7 @@ func (s *UpgradeService) CreateUpgrade(ctx context.Context, req *v1.CreateUpgrad
 	// Store it
 	err = s.store.CreateUpgrade(ctx, upgrade)
 	if err != nil {
-		if errors.Is(err, store.ErrAlreadyExists) {
+		if store.IsAlreadyExists(err) {
 			return nil, status.Errorf(codes.AlreadyExists, "upgrade %q already exists", req.Name)
 		}
 		s.logger.Error("failed to create upgrade", "name", req.Name, "error", err)
@@ -106,7 +105,7 @@ func (s *UpgradeService) GetUpgrade(ctx context.Context, req *v1.GetUpgradeReque
 
 	upgrade, err := s.store.GetUpgrade(ctx, namespace, req.Name)
 	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
+		if store.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "upgrade %q not found", req.Name)
 		}
 		s.logger.Error("failed to get upgrade", "name", req.Name, "error", err)
@@ -152,7 +151,7 @@ func (s *UpgradeService) DeleteUpgrade(ctx context.Context, req *v1.DeleteUpgrad
 	// Check if upgrade exists and is in a terminal state
 	upgrade, err := s.store.GetUpgrade(ctx, namespace, req.Name)
 	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
+		if store.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "upgrade %q not found", req.Name)
 		}
 		s.logger.Error("failed to get upgrade", "name", req.Name, "error", err)
@@ -190,7 +189,7 @@ func (s *UpgradeService) CancelUpgrade(ctx context.Context, req *v1.CancelUpgrad
 
 	upgrade, err := s.store.GetUpgrade(ctx, namespace, req.Name)
 	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
+		if store.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "upgrade %q not found", req.Name)
 		}
 		s.logger.Error("failed to get upgrade", "name", req.Name, "error", err)
@@ -238,7 +237,7 @@ func (s *UpgradeService) RetryUpgrade(ctx context.Context, req *v1.RetryUpgradeR
 
 	upgrade, err := s.store.GetUpgrade(ctx, namespace, req.Name)
 	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
+		if store.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "upgrade %q not found", req.Name)
 		}
 		s.logger.Error("failed to get upgrade", "name", req.Name, "error", err)


### PR DESCRIPTION
## Summary
- Fixed infinite reconcile loop when deleting devnets
- Changed `errors.Is(err, store.ErrNotFound)` to `store.IsNotFound(err)` which correctly handles both sentinel and struct error types
- Fixed 14 occurrences across 4 files

## Test plan
- [x] All existing tests pass
- [x] `TestDevnetController_ReconcileNotFound` confirms fix