### PR TITLE
feat: add binary version selection to provision wizard

### DIFF
--- a/cmd/dvb/provision.go
+++ b/cmd/dvb/provision.go
@@ -67,7 +67,7 @@ Examples:
 
 			// Interactive wizard mode
 			if opts.interactive {
-				wizardOpts, err := RunProvisionWizard()
+				wizardOpts, err := RunProvisionWizard(daemonClient)
 				if err != nil {
 					if err.Error() == "cancelled" {
 						return nil
@@ -85,6 +85,7 @@ Examples:
 				opts.networkType = wizardOpts.ForkNetwork // Map fork network to network type
 				opts.mode = wizardOpts.Mode
 				opts.chainID = wizardOpts.ChainID
+				opts.sdkVersion = wizardOpts.BinaryVersion
 			}
 			return runProvision(cmd.Context(), opts)
 		},

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -198,3 +198,8 @@ func (c *Client) ListNetworks(ctx context.Context) ([]*v1.NetworkSummary, error)
 func (c *Client) GetNetworkInfo(ctx context.Context, name string) (*v1.NetworkInfo, error) {
 	return c.grpc.GetNetworkInfo(ctx, name)
 }
+
+// ListBinaryVersions returns available binary versions for a network.
+func (c *Client) ListBinaryVersions(ctx context.Context, networkName string, includePrerelease bool) (*v1.ListBinaryVersionsResponse, error) {
+	return c.grpc.ListBinaryVersions(ctx, networkName, includePrerelease)
+}

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -491,6 +491,18 @@ func (c *GRPCClient) GetNetworkInfo(ctx context.Context, name string) (*v1.Netwo
 	return resp.Network, nil
 }
 
+// ListBinaryVersions returns available binary versions for a network.
+func (c *GRPCClient) ListBinaryVersions(ctx context.Context, networkName string, includePrerelease bool) (*v1.ListBinaryVersionsResponse, error) {
+	resp, err := c.network.ListBinaryVersions(ctx, &v1.ListBinaryVersionsRequest{
+		NetworkName:       networkName,
+		IncludePrerelease: includePrerelease,
+	})
+	if err != nil {
+		return nil, wrapGRPCError(err)
+	}
+	return resp, nil
+}
+
 // LogEntry represents a single log line from a node.
 type LogEntry struct {
 	Timestamp time.Time


### PR DESCRIPTION
## Summary
- Add ListBinaryVersions client method to fetch available versions from daemon
- Add binary version prompt to provision wizard when forking from snapshot
- Transfer selected version to DevnetSpec for server-side validation

## Changes
- `internal/client/grpc.go`: Added ListBinaryVersions gRPC call wrapper
- `internal/client/client.go`: Added ListBinaryVersions facade method
- `cmd/dvb/wizard.go`: Added BinaryVersion field and promptBinaryVersion helper
- `cmd/dvb/provision.go`: Pass daemonClient to wizard and transfer BinaryVersion

## Test plan
- [x] Build passes
- [x] Client tests pass
- [x] Manual testing with dvb provision -i