### PR TITLE
feat: add -o yaml flag to provision command

### DIFF
--- a/cmd/dvb/provision_test.go
+++ b/cmd/dvb/provision_test.go
@@ -1,0 +1,81 @@
+// cmd/dvb/provision_test.go
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestFormatProvisionYAML(t *testing.T) {
+	opts := &provisionOptions{
+		name:        "test-devnet",
+		namespace:   "production",
+		network:     "stable",
+		networkType: "mainnet",
+		validators:  4,
+		fullNodes:   1,
+		mode:        "docker",
+		chainID:     "mainnet-1",
+		sdkVersion:  "v1.0.0",
+	}
+
+	var buf bytes.Buffer
+	if err := formatProvisionYAML(&buf, opts); err != nil {
+		t.Fatalf("formatProvisionYAML failed: %v", err)
+	}
+
+	output := buf.String()
+
+	expectedFields := []string{
+		"apiVersion: devnet.lagos/v1",
+		"kind: Devnet",
+		"name: test-devnet",
+		"namespace: production",
+		"network: stable",
+		"networkType: mainnet",
+		"networkVersion: v1.0.0",
+		"validators: 4",
+		"fullNodes: 1",
+		"mode: docker",
+		"chainId: mainnet-1",
+		"forkNetwork: mainnet",
+	}
+
+	for _, field := range expectedFields {
+		if !strings.Contains(output, field) {
+			t.Errorf("missing '%s' in output:\n%s", field, output)
+		}
+	}
+}
+
+func TestFormatProvisionYAML_OmitsEmptyFields(t *testing.T) {
+	opts := &provisionOptions{
+		name:       "minimal-devnet",
+		network:    "stable",
+		validators: 2,
+		mode:       "docker",
+	}
+
+	var buf bytes.Buffer
+	if err := formatProvisionYAML(&buf, opts); err != nil {
+		t.Fatalf("formatProvisionYAML failed: %v", err)
+	}
+
+	output := buf.String()
+
+	unexpectedFields := []string{
+		"networkType:",
+		"networkVersion:",
+		"fullNodes:",
+		"chainId:",
+		"namespace:",
+		"forkNetwork:",
+	}
+
+	for _, field := range unexpectedFields {
+		if strings.Contains(output, field) {
+			t.Errorf("should omit '%s' when empty, got:\n%s", field, output)
+		}
+	}
+}


### PR DESCRIPTION
Adds `-o/--output yaml` flag to provision command that outputs the devnet spec as YAML without creating the devnet.

## Usage
```bash
dvb provision --name my-devnet -o yaml
dvb provision --name my-devnet --network stable --validators 4 -o yaml > devnet.yaml
```

## Changes
- Add `output` field to provisionOptions
- Add `-o/--output` flag with yaml option
- Add YAML output types and formatting functions
- Add tests for YAML output