### PR TITLE
feat(ante): add request validation ante handler

### DIFF
--- a/internal/daemon/server/ante/ante.go
+++ b/internal/daemon/server/ante/ante.go
@@ -1,0 +1,153 @@
+// internal/daemon/server/ante/ante.go
+package ante
+
+import (
+	"context"
+
+	v1 "github.com/altuslabsxyz/devnet-builder/api/proto/gen/v1"
+	"github.com/altuslabsxyz/devnet-builder/internal/daemon/types"
+)
+
+// AnteHandler validates requests before they reach service logic.
+// It chains three validation layers: field → spec → reference.
+type AnteHandler struct {
+	field     FieldValidator
+	spec      SpecValidator
+	reference ReferenceValidator
+}
+
+// New creates an AnteHandler with all validation layers.
+func New(store Store, networkSvc NetworkService) *AnteHandler {
+	return &AnteHandler{
+		field:     NewFieldValidator(),
+		spec:      NewSpecValidator(),
+		reference: NewReferenceValidator(store, networkSvc),
+	}
+}
+
+// ValidateCreateDevnet validates a CreateDevnetRequest through all layers.
+func (h *AnteHandler) ValidateCreateDevnet(ctx context.Context, req *v1.CreateDevnetRequest) error {
+	if err := h.field.ValidateCreateDevnetRequest(ctx, req); err != nil {
+		return err
+	}
+
+	if err := h.spec.ValidateDevnetSpec(ctx, req.Spec); err != nil {
+		return err
+	}
+
+	namespace := req.Namespace
+	if namespace == "" {
+		namespace = types.DefaultNamespace
+	}
+	if err := h.reference.ValidateDevnetReferences(ctx, namespace, req.Spec); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ValidateApplyDevnet validates an ApplyDevnetRequest through all layers.
+func (h *AnteHandler) ValidateApplyDevnet(ctx context.Context, req *v1.ApplyDevnetRequest) error {
+	if err := h.field.ValidateApplyDevnetRequest(ctx, req); err != nil {
+		return err
+	}
+
+	if err := h.spec.ValidateDevnetSpec(ctx, req.Spec); err != nil {
+		return err
+	}
+
+	namespace := req.Namespace
+	if namespace == "" {
+		namespace = types.DefaultNamespace
+	}
+	if err := h.reference.ValidateDevnetReferences(ctx, namespace, req.Spec); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ValidateUpdateDevnet validates an UpdateDevnetRequest through all layers.
+func (h *AnteHandler) ValidateUpdateDevnet(ctx context.Context, req *v1.UpdateDevnetRequest) error {
+	if err := h.field.ValidateUpdateDevnetRequest(ctx, req); err != nil {
+		return err
+	}
+
+	if req.Spec != nil {
+		if err := h.spec.ValidateDevnetSpec(ctx, req.Spec); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ValidateCreateUpgrade validates a CreateUpgradeRequest through all layers.
+func (h *AnteHandler) ValidateCreateUpgrade(ctx context.Context, req *v1.CreateUpgradeRequest) error {
+	if err := h.field.ValidateCreateUpgradeRequest(ctx, req); err != nil {
+		return err
+	}
+
+	if err := h.spec.ValidateUpgradeSpec(ctx, req.Spec); err != nil {
+		return err
+	}
+
+	namespace := req.Namespace
+	if namespace == "" {
+		namespace = types.DefaultNamespace
+	}
+	if err := h.reference.ValidateUpgradeReferences(ctx, namespace, req.Spec); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ValidateStartNode validates a StartNodeRequest.
+func (h *AnteHandler) ValidateStartNode(ctx context.Context, req *v1.StartNodeRequest) error {
+	if err := h.field.ValidateStartNodeRequest(ctx, req); err != nil {
+		return err
+	}
+
+	namespace := req.Namespace
+	if namespace == "" {
+		namespace = types.DefaultNamespace
+	}
+	return h.reference.ValidateNodeReferences(ctx, namespace, req.DevnetName, int(req.Index))
+}
+
+// ValidateStopNode validates a StopNodeRequest.
+func (h *AnteHandler) ValidateStopNode(ctx context.Context, req *v1.StopNodeRequest) error {
+	if err := h.field.ValidateStopNodeRequest(ctx, req); err != nil {
+		return err
+	}
+
+	namespace := req.Namespace
+	if namespace == "" {
+		namespace = types.DefaultNamespace
+	}
+	return h.reference.ValidateNodeReferences(ctx, namespace, req.DevnetName, int(req.Index))
+}
+
+// ValidateRestartNode validates a RestartNodeRequest.
+func (h *AnteHandler) ValidateRestartNode(ctx context.Context, req *v1.RestartNodeRequest) error {
+	if err := h.field.ValidateRestartNodeRequest(ctx, req); err != nil {
+		return err
+	}
+
+	namespace := req.Namespace
+	if namespace == "" {
+		namespace = types.DefaultNamespace
+	}
+	return h.reference.ValidateNodeReferences(ctx, namespace, req.DevnetName, int(req.Index))
+}
+
+// ValidateGetNode validates a GetNodeRequest.
+func (h *AnteHandler) ValidateGetNode(ctx context.Context, req *v1.GetNodeRequest) error {
+	return h.field.ValidateGetNodeRequest(ctx, req)
+}
+
+// ValidateGetNodeHealth validates a GetNodeHealthRequest.
+func (h *AnteHandler) ValidateGetNodeHealth(ctx context.Context, req *v1.GetNodeHealthRequest) error {
+	return h.field.ValidateGetNodeHealthRequest(ctx, req)
+}

--- a/internal/daemon/server/ante/ante_test.go
+++ b/internal/daemon/server/ante/ante_test.go
@@ -1,0 +1,157 @@
+// internal/daemon/server/ante/ante_test.go
+package ante
+
+import (
+	"context"
+	"testing"
+
+	v1 "github.com/altuslabsxyz/devnet-builder/api/proto/gen/v1"
+	"github.com/altuslabsxyz/devnet-builder/internal/daemon/types"
+)
+
+func TestAnteHandler_ValidateCreateDevnet(t *testing.T) {
+	store := newMockStore()
+	networkSvc := newMockNetworkService()
+	handler := New(store, networkSvc)
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		req     *v1.CreateDevnetRequest
+		wantErr bool
+	}{
+		{
+			name: "valid request",
+			req: &v1.CreateDevnetRequest{
+				Name: "test",
+				Spec: &v1.DevnetSpec{Plugin: "stable", Mode: "docker", Validators: 2},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing name (field validation)",
+			req: &v1.CreateDevnetRequest{
+				Name: "",
+				Spec: &v1.DevnetSpec{Plugin: "stable", Mode: "docker"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid mode (spec validation)",
+			req: &v1.CreateDevnetRequest{
+				Name: "test",
+				Spec: &v1.DevnetSpec{Plugin: "stable", Mode: "invalid"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown network (reference validation)",
+			req: &v1.CreateDevnetRequest{
+				Name: "test",
+				Spec: &v1.DevnetSpec{Plugin: "unknown", Mode: "docker"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := handler.ValidateCreateDevnet(ctx, tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCreateDevnet() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAnteHandler_ValidateApplyDevnet(t *testing.T) {
+	store := newMockStore()
+	networkSvc := newMockNetworkService()
+	handler := New(store, networkSvc)
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		req     *v1.ApplyDevnetRequest
+		wantErr bool
+	}{
+		{
+			name: "valid request",
+			req: &v1.ApplyDevnetRequest{
+				Name: "test",
+				Spec: &v1.DevnetSpec{Plugin: "stable", Mode: "docker"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing name",
+			req: &v1.ApplyDevnetRequest{
+				Name: "",
+				Spec: &v1.DevnetSpec{Plugin: "stable", Mode: "docker"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := handler.ValidateApplyDevnet(ctx, tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateApplyDevnet() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAnteHandler_ValidateCreateUpgrade(t *testing.T) {
+	store := newMockStore()
+	store.devnets["default/my-devnet"] = &types.Devnet{
+		Metadata: types.ResourceMeta{Name: "my-devnet", Namespace: "default"},
+	}
+	networkSvc := newMockNetworkService()
+	handler := New(store, networkSvc)
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		req     *v1.CreateUpgradeRequest
+		wantErr bool
+	}{
+		{
+			name: "valid request",
+			req: &v1.CreateUpgradeRequest{
+				Name:      "upgrade-1",
+				Namespace: "default",
+				Spec:      &v1.UpgradeSpec{DevnetRef: "my-devnet", UpgradeName: "v2", TargetHeight: 100},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing devnet_ref (field validation)",
+			req: &v1.CreateUpgradeRequest{
+				Name:      "upgrade-1",
+				Namespace: "default",
+				Spec:      &v1.UpgradeSpec{DevnetRef: "", UpgradeName: "v2"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "devnet not found (reference validation)",
+			req: &v1.CreateUpgradeRequest{
+				Name:      "upgrade-1",
+				Namespace: "default",
+				Spec:      &v1.UpgradeSpec{DevnetRef: "nonexistent", UpgradeName: "v2"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := handler.ValidateCreateUpgrade(ctx, tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCreateUpgrade() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/daemon/server/ante/errors.go
+++ b/internal/daemon/server/ante/errors.go
@@ -1,0 +1,91 @@
+// internal/daemon/server/ante/errors.go
+package ante
+
+import (
+	"fmt"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Error codes for validation failures.
+const (
+	CodeRequired          = "required"
+	CodeInvalidRange      = "invalid_range"
+	CodeInvalidValue      = "invalid_value"
+	CodeInvalidFormat     = "invalid_format"
+	CodeNotFound          = "not_found"
+	CodeMutuallyExclusive = "mutually_exclusive"
+	CodeValidationFailed  = "validation_failed"
+)
+
+// ValidationError represents a single validation failure.
+type ValidationError struct {
+	Field   string
+	Code    string
+	Message string
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Field, e.Message)
+}
+
+// GRPCCode returns the appropriate gRPC status code.
+func (e *ValidationError) GRPCCode() codes.Code {
+	switch e.Code {
+	case CodeNotFound:
+		return codes.NotFound
+	default:
+		return codes.InvalidArgument
+	}
+}
+
+// MultiValidationError collects multiple validation failures.
+type MultiValidationError struct {
+	Errors []*ValidationError
+}
+
+func (e *MultiValidationError) Error() string {
+	if len(e.Errors) == 1 {
+		return e.Errors[0].Error()
+	}
+
+	var msgs []string
+	for _, err := range e.Errors {
+		msgs = append(msgs, fmt.Sprintf("  - %s", err.Error()))
+	}
+	return fmt.Sprintf("validation failed:\n%s", strings.Join(msgs, "\n"))
+}
+
+// GRPCCode returns InvalidArgument for multiple errors.
+func (e *MultiValidationError) GRPCCode() codes.Code {
+	return codes.InvalidArgument
+}
+
+// ToGRPCError converts validation errors to gRPC status errors.
+func ToGRPCError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch e := err.(type) {
+	case *ValidationError:
+		return status.Error(e.GRPCCode(), e.Error())
+	case *MultiValidationError:
+		return status.Error(e.GRPCCode(), e.Error())
+	default:
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
+}
+
+// toError converts a slice of validation errors to a single error.
+func toError(errs []*ValidationError) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	if len(errs) == 1 {
+		return errs[0]
+	}
+	return &MultiValidationError{Errors: errs}
+}

--- a/internal/daemon/server/ante/errors_test.go
+++ b/internal/daemon/server/ante/errors_test.go
@@ -1,0 +1,87 @@
+// internal/daemon/server/ante/errors_test.go
+package ante
+
+import (
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+)
+
+func TestValidationError_Error(t *testing.T) {
+	err := &ValidationError{
+		Field:   "spec.network",
+		Code:    CodeRequired,
+		Message: "network is required",
+	}
+
+	got := err.Error()
+	want := "spec.network: network is required"
+	if got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestValidationError_GRPCCode(t *testing.T) {
+	tests := []struct {
+		code string
+		want codes.Code
+	}{
+		{CodeRequired, codes.InvalidArgument},
+		{CodeInvalidRange, codes.InvalidArgument},
+		{CodeNotFound, codes.NotFound},
+	}
+
+	for _, tt := range tests {
+		err := &ValidationError{Code: tt.code}
+		if got := err.GRPCCode(); got != tt.want {
+			t.Errorf("GRPCCode() for %s = %v, want %v", tt.code, got, tt.want)
+		}
+	}
+}
+
+func TestMultiValidationError_Error(t *testing.T) {
+	err := &MultiValidationError{
+		Errors: []*ValidationError{
+			{Field: "name", Code: CodeRequired, Message: "name is required"},
+			{Field: "spec.mode", Code: CodeInvalidValue, Message: "mode must be 'docker' or 'local'"},
+		},
+	}
+
+	got := err.Error()
+	if got == "" {
+		t.Error("Error() returned empty string")
+	}
+	// Should contain both errors
+	if !strings.Contains(got, "name: name is required") {
+		t.Error("Error() missing first error")
+	}
+	if !strings.Contains(got, "spec.mode: mode must be 'docker' or 'local'") {
+		t.Error("Error() missing second error")
+	}
+}
+
+func TestToError_Nil(t *testing.T) {
+	if err := toError(nil); err != nil {
+		t.Errorf("toError(nil) = %v, want nil", err)
+	}
+}
+
+func TestToError_Single(t *testing.T) {
+	errs := []*ValidationError{{Field: "name", Code: CodeRequired, Message: "required"}}
+	err := toError(errs)
+	if _, ok := err.(*ValidationError); !ok {
+		t.Errorf("toError with single error should return *ValidationError, got %T", err)
+	}
+}
+
+func TestToError_Multiple(t *testing.T) {
+	errs := []*ValidationError{
+		{Field: "name", Code: CodeRequired, Message: "required"},
+		{Field: "spec", Code: CodeRequired, Message: "required"},
+	}
+	err := toError(errs)
+	if _, ok := err.(*MultiValidationError); !ok {
+		t.Errorf("toError with multiple errors should return *MultiValidationError, got %T", err)
+	}
+}

--- a/internal/daemon/server/ante/field_validator.go
+++ b/internal/daemon/server/ante/field_validator.go
@@ -1,0 +1,181 @@
+// internal/daemon/server/ante/field_validator.go
+package ante
+
+import (
+	"context"
+
+	v1 "github.com/altuslabsxyz/devnet-builder/api/proto/gen/v1"
+)
+
+// FieldValidator validates required fields are present.
+type FieldValidator interface {
+	ValidateCreateDevnetRequest(ctx context.Context, req *v1.CreateDevnetRequest) error
+	ValidateApplyDevnetRequest(ctx context.Context, req *v1.ApplyDevnetRequest) error
+	ValidateUpdateDevnetRequest(ctx context.Context, req *v1.UpdateDevnetRequest) error
+	ValidateCreateUpgradeRequest(ctx context.Context, req *v1.CreateUpgradeRequest) error
+	ValidateStartNodeRequest(ctx context.Context, req *v1.StartNodeRequest) error
+	ValidateStopNodeRequest(ctx context.Context, req *v1.StopNodeRequest) error
+	ValidateRestartNodeRequest(ctx context.Context, req *v1.RestartNodeRequest) error
+	ValidateGetNodeRequest(ctx context.Context, req *v1.GetNodeRequest) error
+	ValidateGetNodeHealthRequest(ctx context.Context, req *v1.GetNodeHealthRequest) error
+}
+
+type fieldValidator struct{}
+
+// NewFieldValidator creates a new FieldValidator instance.
+func NewFieldValidator() FieldValidator {
+	return &fieldValidator{}
+}
+
+// ValidateCreateDevnetRequest validates required fields for creating a devnet.
+func (v *fieldValidator) ValidateCreateDevnetRequest(ctx context.Context, req *v1.CreateDevnetRequest) error {
+	var errs []*ValidationError
+
+	if req.Name == "" {
+		errs = append(errs, &ValidationError{Field: "name", Code: CodeRequired, Message: "name is required"})
+	}
+
+	if req.Spec == nil {
+		errs = append(errs, &ValidationError{Field: "spec", Code: CodeRequired, Message: "spec is required"})
+	} else {
+		if req.Spec.Plugin == "" {
+			errs = append(errs, &ValidationError{Field: "spec.plugin", Code: CodeRequired, Message: "plugin is required"})
+		}
+		if req.Spec.Mode == "" {
+			errs = append(errs, &ValidationError{Field: "spec.mode", Code: CodeRequired, Message: "mode is required"})
+		}
+	}
+
+	return toError(errs)
+}
+
+// ValidateApplyDevnetRequest validates required fields for applying a devnet.
+func (v *fieldValidator) ValidateApplyDevnetRequest(ctx context.Context, req *v1.ApplyDevnetRequest) error {
+	var errs []*ValidationError
+
+	if req.Name == "" {
+		errs = append(errs, &ValidationError{Field: "name", Code: CodeRequired, Message: "name is required"})
+	}
+
+	if req.Spec == nil {
+		errs = append(errs, &ValidationError{Field: "spec", Code: CodeRequired, Message: "spec is required"})
+	} else {
+		if req.Spec.Plugin == "" {
+			errs = append(errs, &ValidationError{Field: "spec.plugin", Code: CodeRequired, Message: "plugin is required"})
+		}
+		if req.Spec.Mode == "" {
+			errs = append(errs, &ValidationError{Field: "spec.mode", Code: CodeRequired, Message: "mode is required"})
+		}
+	}
+
+	return toError(errs)
+}
+
+// ValidateUpdateDevnetRequest validates required fields for updating a devnet.
+// Note: UpdateDevnetRequest supports partial updates, so spec is not required.
+func (v *fieldValidator) ValidateUpdateDevnetRequest(ctx context.Context, req *v1.UpdateDevnetRequest) error {
+	var errs []*ValidationError
+
+	if req.Name == "" {
+		errs = append(errs, &ValidationError{Field: "name", Code: CodeRequired, Message: "name is required"})
+	}
+
+	return toError(errs)
+}
+
+// ValidateCreateUpgradeRequest validates required fields for creating an upgrade.
+func (v *fieldValidator) ValidateCreateUpgradeRequest(ctx context.Context, req *v1.CreateUpgradeRequest) error {
+	var errs []*ValidationError
+
+	if req.Name == "" {
+		errs = append(errs, &ValidationError{Field: "name", Code: CodeRequired, Message: "name is required"})
+	}
+
+	if req.Spec == nil {
+		errs = append(errs, &ValidationError{Field: "spec", Code: CodeRequired, Message: "spec is required"})
+	} else {
+		if req.Spec.DevnetRef == "" {
+			errs = append(errs, &ValidationError{Field: "spec.devnet_ref", Code: CodeRequired, Message: "devnet_ref is required"})
+		}
+		if req.Spec.UpgradeName == "" {
+			errs = append(errs, &ValidationError{Field: "spec.upgrade_name", Code: CodeRequired, Message: "upgrade_name is required"})
+		}
+	}
+
+	return toError(errs)
+}
+
+// ValidateStartNodeRequest validates required fields for starting a node.
+func (v *fieldValidator) ValidateStartNodeRequest(ctx context.Context, req *v1.StartNodeRequest) error {
+	var errs []*ValidationError
+
+	if req.DevnetName == "" {
+		errs = append(errs, &ValidationError{Field: "devnet_name", Code: CodeRequired, Message: "devnet_name is required"})
+	}
+
+	if req.Index < 0 {
+		errs = append(errs, &ValidationError{Field: "index", Code: CodeInvalidRange, Message: "index must be non-negative"})
+	}
+
+	return toError(errs)
+}
+
+// ValidateStopNodeRequest validates required fields for stopping a node.
+func (v *fieldValidator) ValidateStopNodeRequest(ctx context.Context, req *v1.StopNodeRequest) error {
+	var errs []*ValidationError
+
+	if req.DevnetName == "" {
+		errs = append(errs, &ValidationError{Field: "devnet_name", Code: CodeRequired, Message: "devnet_name is required"})
+	}
+
+	if req.Index < 0 {
+		errs = append(errs, &ValidationError{Field: "index", Code: CodeInvalidRange, Message: "index must be non-negative"})
+	}
+
+	return toError(errs)
+}
+
+// ValidateRestartNodeRequest validates required fields for restarting a node.
+func (v *fieldValidator) ValidateRestartNodeRequest(ctx context.Context, req *v1.RestartNodeRequest) error {
+	var errs []*ValidationError
+
+	if req.DevnetName == "" {
+		errs = append(errs, &ValidationError{Field: "devnet_name", Code: CodeRequired, Message: "devnet_name is required"})
+	}
+
+	if req.Index < 0 {
+		errs = append(errs, &ValidationError{Field: "index", Code: CodeInvalidRange, Message: "index must be non-negative"})
+	}
+
+	return toError(errs)
+}
+
+// ValidateGetNodeRequest validates required fields for getting a node.
+func (v *fieldValidator) ValidateGetNodeRequest(ctx context.Context, req *v1.GetNodeRequest) error {
+	var errs []*ValidationError
+
+	if req.DevnetName == "" {
+		errs = append(errs, &ValidationError{Field: "devnet_name", Code: CodeRequired, Message: "devnet_name is required"})
+	}
+
+	if req.Index < 0 {
+		errs = append(errs, &ValidationError{Field: "index", Code: CodeInvalidRange, Message: "index must be non-negative"})
+	}
+
+	return toError(errs)
+}
+
+// ValidateGetNodeHealthRequest validates required fields for getting node health.
+func (v *fieldValidator) ValidateGetNodeHealthRequest(ctx context.Context, req *v1.GetNodeHealthRequest) error {
+	var errs []*ValidationError
+
+	if req.DevnetName == "" {
+		errs = append(errs, &ValidationError{Field: "devnet_name", Code: CodeRequired, Message: "devnet_name is required"})
+	}
+
+	if req.Index < 0 {
+		errs = append(errs, &ValidationError{Field: "index", Code: CodeInvalidRange, Message: "index must be non-negative"})
+	}
+
+	return toError(errs)
+}

--- a/internal/daemon/server/ante/field_validator_test.go
+++ b/internal/daemon/server/ante/field_validator_test.go
@@ -1,0 +1,378 @@
+// internal/daemon/server/ante/field_validator_test.go
+package ante
+
+import (
+	"context"
+	"testing"
+
+	v1 "github.com/altuslabsxyz/devnet-builder/api/proto/gen/v1"
+)
+
+func TestFieldValidator_CreateDevnetRequest(t *testing.T) {
+	v := NewFieldValidator()
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		req     *v1.CreateDevnetRequest
+		wantErr bool
+		field   string
+	}{
+		{
+			name:    "valid request",
+			req:     &v1.CreateDevnetRequest{Name: "test", Spec: &v1.DevnetSpec{Plugin: "stable", Mode: "docker"}},
+			wantErr: false,
+		},
+		{
+			name:    "missing name",
+			req:     &v1.CreateDevnetRequest{Name: "", Spec: &v1.DevnetSpec{Plugin: "stable", Mode: "docker"}},
+			wantErr: true,
+			field:   "name",
+		},
+		{
+			name:    "missing spec",
+			req:     &v1.CreateDevnetRequest{Name: "test", Spec: nil},
+			wantErr: true,
+			field:   "spec",
+		},
+		{
+			name:    "missing plugin",
+			req:     &v1.CreateDevnetRequest{Name: "test", Spec: &v1.DevnetSpec{Plugin: "", Mode: "docker"}},
+			wantErr: true,
+			field:   "spec.plugin",
+		},
+		{
+			name:    "missing mode",
+			req:     &v1.CreateDevnetRequest{Name: "test", Spec: &v1.DevnetSpec{Plugin: "stable", Mode: ""}},
+			wantErr: true,
+			field:   "spec.mode",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.ValidateCreateDevnetRequest(ctx, tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCreateDevnetRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && tt.field != "" {
+				ve, ok := err.(*ValidationError)
+				if !ok {
+					t.Errorf("expected *ValidationError, got %T", err)
+					return
+				}
+				if ve.Field != tt.field {
+					t.Errorf("error field = %s, want %s", ve.Field, tt.field)
+				}
+			}
+		})
+	}
+}
+
+func TestFieldValidator_ApplyDevnetRequest(t *testing.T) {
+	v := NewFieldValidator()
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		req     *v1.ApplyDevnetRequest
+		wantErr bool
+		field   string
+	}{
+		{
+			name:    "valid",
+			req:     &v1.ApplyDevnetRequest{Name: "test", Spec: &v1.DevnetSpec{Plugin: "stable", Mode: "docker"}},
+			wantErr: false,
+		},
+		{
+			name:    "missing name",
+			req:     &v1.ApplyDevnetRequest{Name: "", Spec: &v1.DevnetSpec{Plugin: "stable", Mode: "docker"}},
+			wantErr: true,
+			field:   "name",
+		},
+		{
+			name:    "missing spec",
+			req:     &v1.ApplyDevnetRequest{Name: "test", Spec: nil},
+			wantErr: true,
+			field:   "spec",
+		},
+		{
+			name:    "missing plugin",
+			req:     &v1.ApplyDevnetRequest{Name: "test", Spec: &v1.DevnetSpec{Plugin: "", Mode: "docker"}},
+			wantErr: true,
+			field:   "spec.plugin",
+		},
+		{
+			name:    "missing mode",
+			req:     &v1.ApplyDevnetRequest{Name: "test", Spec: &v1.DevnetSpec{Plugin: "stable", Mode: ""}},
+			wantErr: true,
+			field:   "spec.mode",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.ValidateApplyDevnetRequest(ctx, tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateApplyDevnetRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && tt.field != "" {
+				ve, ok := err.(*ValidationError)
+				if !ok {
+					t.Errorf("expected *ValidationError, got %T", err)
+					return
+				}
+				if ve.Field != tt.field {
+					t.Errorf("error field = %s, want %s", ve.Field, tt.field)
+				}
+			}
+		})
+	}
+}
+
+func TestFieldValidator_UpdateDevnetRequest(t *testing.T) {
+	v := NewFieldValidator()
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		req     *v1.UpdateDevnetRequest
+		wantErr bool
+		field   string
+	}{
+		{
+			name:    "valid with spec",
+			req:     &v1.UpdateDevnetRequest{Name: "test", Spec: &v1.DevnetSpec{Plugin: "stable"}},
+			wantErr: false,
+		},
+		{
+			name:    "valid without spec (partial update)",
+			req:     &v1.UpdateDevnetRequest{Name: "test"},
+			wantErr: false,
+		},
+		{
+			name:    "missing name",
+			req:     &v1.UpdateDevnetRequest{Name: ""},
+			wantErr: true,
+			field:   "name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.ValidateUpdateDevnetRequest(ctx, tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUpdateDevnetRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && tt.field != "" {
+				ve, ok := err.(*ValidationError)
+				if !ok {
+					t.Errorf("expected *ValidationError, got %T", err)
+					return
+				}
+				if ve.Field != tt.field {
+					t.Errorf("error field = %s, want %s", ve.Field, tt.field)
+				}
+			}
+		})
+	}
+}
+
+func TestFieldValidator_CreateUpgradeRequest(t *testing.T) {
+	v := NewFieldValidator()
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		req     *v1.CreateUpgradeRequest
+		wantErr bool
+		field   string
+	}{
+		{
+			name: "valid",
+			req: &v1.CreateUpgradeRequest{
+				Name: "upgrade-1",
+				Spec: &v1.UpgradeSpec{DevnetRef: "my-devnet", UpgradeName: "v2"},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "missing name",
+			req:     &v1.CreateUpgradeRequest{Name: "", Spec: &v1.UpgradeSpec{DevnetRef: "my-devnet", UpgradeName: "v2"}},
+			wantErr: true,
+			field:   "name",
+		},
+		{
+			name:    "missing spec",
+			req:     &v1.CreateUpgradeRequest{Name: "upgrade-1", Spec: nil},
+			wantErr: true,
+			field:   "spec",
+		},
+		{
+			name:    "missing devnet_ref",
+			req:     &v1.CreateUpgradeRequest{Name: "upgrade-1", Spec: &v1.UpgradeSpec{DevnetRef: "", UpgradeName: "v2"}},
+			wantErr: true,
+			field:   "spec.devnet_ref",
+		},
+		{
+			name:    "missing upgrade_name",
+			req:     &v1.CreateUpgradeRequest{Name: "upgrade-1", Spec: &v1.UpgradeSpec{DevnetRef: "my-devnet", UpgradeName: ""}},
+			wantErr: true,
+			field:   "spec.upgrade_name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.ValidateCreateUpgradeRequest(ctx, tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCreateUpgradeRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && tt.field != "" {
+				ve, ok := err.(*ValidationError)
+				if !ok {
+					t.Errorf("expected *ValidationError, got %T", err)
+					return
+				}
+				if ve.Field != tt.field {
+					t.Errorf("error field = %s, want %s", ve.Field, tt.field)
+				}
+			}
+		})
+	}
+}
+
+func TestFieldValidator_StartNodeRequest(t *testing.T) {
+	v := NewFieldValidator()
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		req     *v1.StartNodeRequest
+		wantErr bool
+		field   string
+	}{
+		{
+			name:    "valid",
+			req:     &v1.StartNodeRequest{DevnetName: "my-devnet", Index: 0},
+			wantErr: false,
+		},
+		{
+			name:    "valid with index > 0",
+			req:     &v1.StartNodeRequest{DevnetName: "my-devnet", Index: 5},
+			wantErr: false,
+		},
+		{
+			name:    "missing devnet_name",
+			req:     &v1.StartNodeRequest{DevnetName: "", Index: 0},
+			wantErr: true,
+			field:   "devnet_name",
+		},
+		{
+			name:    "negative index",
+			req:     &v1.StartNodeRequest{DevnetName: "my-devnet", Index: -1},
+			wantErr: true,
+			field:   "index",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.ValidateStartNodeRequest(ctx, tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateStartNodeRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && tt.field != "" {
+				ve, ok := err.(*ValidationError)
+				if !ok {
+					t.Errorf("expected *ValidationError, got %T", err)
+					return
+				}
+				if ve.Field != tt.field {
+					t.Errorf("error field = %s, want %s", ve.Field, tt.field)
+				}
+			}
+		})
+	}
+}
+
+func TestFieldValidator_GetNodeRequest(t *testing.T) {
+	v := NewFieldValidator()
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		req     *v1.GetNodeRequest
+		wantErr bool
+		field   string
+	}{
+		{
+			name:    "valid",
+			req:     &v1.GetNodeRequest{DevnetName: "my-devnet", Index: 0},
+			wantErr: false,
+		},
+		{
+			name:    "valid with index > 0",
+			req:     &v1.GetNodeRequest{DevnetName: "my-devnet", Index: 3},
+			wantErr: false,
+		},
+		{
+			name:    "missing devnet_name",
+			req:     &v1.GetNodeRequest{DevnetName: "", Index: 0},
+			wantErr: true,
+			field:   "devnet_name",
+		},
+		{
+			name:    "negative index",
+			req:     &v1.GetNodeRequest{DevnetName: "my-devnet", Index: -1},
+			wantErr: true,
+			field:   "index",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.ValidateGetNodeRequest(ctx, tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateGetNodeRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && tt.field != "" {
+				ve, ok := err.(*ValidationError)
+				if !ok {
+					t.Errorf("expected *ValidationError, got %T", err)
+					return
+				}
+				if ve.Field != tt.field {
+					t.Errorf("error field = %s, want %s", ve.Field, tt.field)
+				}
+			}
+		})
+	}
+}
+
+func TestFieldValidator_MultipleErrors(t *testing.T) {
+	v := NewFieldValidator()
+	ctx := context.Background()
+
+	// Test that multiple validation errors are collected
+	req := &v1.CreateDevnetRequest{
+		Name: "",  // Missing name
+		Spec: nil, // Missing spec
+	}
+
+	err := v.ValidateCreateDevnetRequest(ctx, req)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	// Should be a MultiValidationError when multiple fields fail
+	mve, ok := err.(*MultiValidationError)
+	if !ok {
+		t.Errorf("expected *MultiValidationError for multiple errors, got %T", err)
+		return
+	}
+
+	if len(mve.Errors) < 2 {
+		t.Errorf("expected at least 2 errors, got %d", len(mve.Errors))
+	}
+}

--- a/internal/daemon/server/ante/reference_validator.go
+++ b/internal/daemon/server/ante/reference_validator.go
@@ -1,0 +1,110 @@
+// internal/daemon/server/ante/reference_validator.go
+package ante
+
+import (
+	"context"
+	"fmt"
+
+	v1 "github.com/altuslabsxyz/devnet-builder/api/proto/gen/v1"
+	"github.com/altuslabsxyz/devnet-builder/internal/daemon/types"
+)
+
+// Store provides access to persisted resources for validation.
+type Store interface {
+	GetDevnet(ctx context.Context, namespace, name string) (*types.Devnet, error)
+	GetNode(ctx context.Context, namespace, devnetName string, index int) (*types.Node, error)
+}
+
+// NetworkService provides network plugin information for validation.
+type NetworkService interface {
+	GetNetworkInfo(ctx context.Context, req *v1.GetNetworkInfoRequest) (*v1.GetNetworkInfoResponse, error)
+	ListBinaryVersions(ctx context.Context, req *v1.ListBinaryVersionsRequest) (*v1.ListBinaryVersionsResponse, error)
+}
+
+// ReferenceValidator validates cross-resource references and semantic constraints.
+type ReferenceValidator interface {
+	ValidateDevnetReferences(ctx context.Context, namespace string, spec *v1.DevnetSpec) error
+	ValidateUpgradeReferences(ctx context.Context, namespace string, spec *v1.UpgradeSpec) error
+	ValidateNodeReferences(ctx context.Context, namespace, devnetName string, index int) error
+}
+
+type referenceValidator struct {
+	store      Store
+	networkSvc NetworkService
+}
+
+// NewReferenceValidator creates a new reference validator with the given dependencies.
+func NewReferenceValidator(store Store, networkSvc NetworkService) ReferenceValidator {
+	return &referenceValidator{
+		store:      store,
+		networkSvc: networkSvc,
+	}
+}
+
+// ValidateDevnetReferences validates that a DevnetSpec references valid resources.
+// It checks that the plugin (network) exists via the NetworkService.
+func (v *referenceValidator) ValidateDevnetReferences(ctx context.Context, namespace string, spec *v1.DevnetSpec) error {
+	if spec == nil {
+		return nil
+	}
+
+	var errs []*ValidationError
+
+	// Validate plugin/network exists
+	if spec.Plugin != "" {
+		_, err := v.networkSvc.GetNetworkInfo(ctx, &v1.GetNetworkInfoRequest{Name: spec.Plugin})
+		if err != nil {
+			errs = append(errs, &ValidationError{
+				Field:   "spec.plugin",
+				Code:    CodeNotFound,
+				Message: fmt.Sprintf("network plugin '%s' not found", spec.Plugin),
+			})
+		}
+	}
+
+	return toError(errs)
+}
+
+// ValidateUpgradeReferences validates that an UpgradeSpec references valid resources.
+// It checks that the referenced devnet exists in the store.
+func (v *referenceValidator) ValidateUpgradeReferences(ctx context.Context, namespace string, spec *v1.UpgradeSpec) error {
+	if spec == nil {
+		return nil
+	}
+
+	var errs []*ValidationError
+
+	// Validate devnet exists
+	if spec.DevnetRef != "" {
+		_, err := v.store.GetDevnet(ctx, namespace, spec.DevnetRef)
+		if err != nil {
+			errs = append(errs, &ValidationError{
+				Field:   "spec.devnet_ref",
+				Code:    CodeNotFound,
+				Message: fmt.Sprintf("devnet '%s' not found", spec.DevnetRef),
+			})
+		}
+	}
+
+	return toError(errs)
+}
+
+// ValidateNodeReferences validates that a node operation references valid resources.
+// It checks that the referenced devnet exists in the store.
+func (v *referenceValidator) ValidateNodeReferences(ctx context.Context, namespace, devnetName string, index int) error {
+	var errs []*ValidationError
+
+	// Validate devnet exists
+	if devnetName != "" {
+		_, err := v.store.GetDevnet(ctx, namespace, devnetName)
+		if err != nil {
+			errs = append(errs, &ValidationError{
+				Field:   "devnet_name",
+				Code:    CodeNotFound,
+				Message: fmt.Sprintf("devnet '%s' not found", devnetName),
+			})
+		}
+	}
+
+	return toError(errs)
+}

--- a/internal/daemon/server/ante/reference_validator_test.go
+++ b/internal/daemon/server/ante/reference_validator_test.go
@@ -1,0 +1,238 @@
+// internal/daemon/server/ante/reference_validator_test.go
+package ante
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	v1 "github.com/altuslabsxyz/devnet-builder/api/proto/gen/v1"
+	"github.com/altuslabsxyz/devnet-builder/internal/daemon/types"
+)
+
+// mockStore implements the Store interface for testing.
+type mockStore struct {
+	devnets map[string]*types.Devnet
+	nodes   map[string]*types.Node
+}
+
+func newMockStore() *mockStore {
+	return &mockStore{
+		devnets: make(map[string]*types.Devnet),
+		nodes:   make(map[string]*types.Node),
+	}
+}
+
+func (m *mockStore) GetDevnet(ctx context.Context, namespace, name string) (*types.Devnet, error) {
+	key := namespace + "/" + name
+	if d, ok := m.devnets[key]; ok {
+		return d, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (m *mockStore) GetNode(ctx context.Context, namespace, devnetName string, index int) (*types.Node, error) {
+	return nil, errors.New("not found")
+}
+
+// mockNetworkService implements NetworkService for testing.
+type mockNetworkService struct {
+	networks map[string]bool
+}
+
+func newMockNetworkService() *mockNetworkService {
+	return &mockNetworkService{networks: map[string]bool{"stable": true, "osmosis": true}}
+}
+
+func (m *mockNetworkService) GetNetworkInfo(ctx context.Context, req *v1.GetNetworkInfoRequest) (*v1.GetNetworkInfoResponse, error) {
+	if m.networks[req.Name] {
+		return &v1.GetNetworkInfoResponse{Network: &v1.NetworkInfo{Name: req.Name}}, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (m *mockNetworkService) ListBinaryVersions(ctx context.Context, req *v1.ListBinaryVersionsRequest) (*v1.ListBinaryVersionsResponse, error) {
+	return &v1.ListBinaryVersionsResponse{}, nil
+}
+
+func TestReferenceValidator_DevnetReferences(t *testing.T) {
+	store := newMockStore()
+	networkSvc := newMockNetworkService()
+	v := NewReferenceValidator(store, networkSvc)
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		namespace string
+		spec      *v1.DevnetSpec
+		wantErr   bool
+		field     string
+	}{
+		{
+			name:      "valid network",
+			namespace: "default",
+			spec:      &v1.DevnetSpec{Plugin: "stable"},
+			wantErr:   false,
+		},
+		{
+			name:      "nil spec is ok",
+			namespace: "default",
+			spec:      nil,
+			wantErr:   false,
+		},
+		{
+			name:      "unknown network",
+			namespace: "default",
+			spec:      &v1.DevnetSpec{Plugin: "unknown-network"},
+			wantErr:   true,
+			field:     "spec.plugin",
+		},
+		{
+			name:      "empty plugin is ok",
+			namespace: "default",
+			spec:      &v1.DevnetSpec{Plugin: ""},
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.ValidateDevnetReferences(ctx, tt.namespace, tt.spec)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateDevnetReferences() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && tt.field != "" {
+				if ve, ok := err.(*ValidationError); ok {
+					if ve.Field != tt.field {
+						t.Errorf("ValidateDevnetReferences() field = %v, want %v", ve.Field, tt.field)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestReferenceValidator_UpgradeReferences(t *testing.T) {
+	store := newMockStore()
+	store.devnets["default/my-devnet"] = &types.Devnet{
+		Metadata: types.ResourceMeta{Name: "my-devnet", Namespace: "default"},
+		Spec:     types.DevnetSpec{Plugin: "stable"},
+	}
+	networkSvc := newMockNetworkService()
+	v := NewReferenceValidator(store, networkSvc)
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		namespace string
+		devnetRef string
+		spec      *v1.UpgradeSpec
+		wantErr   bool
+		field     string
+	}{
+		{
+			name:      "valid devnet ref",
+			namespace: "default",
+			devnetRef: "my-devnet",
+			spec:      &v1.UpgradeSpec{DevnetRef: "my-devnet", UpgradeName: "v2"},
+			wantErr:   false,
+		},
+		{
+			name:      "nil spec is ok",
+			namespace: "default",
+			devnetRef: "",
+			spec:      nil,
+			wantErr:   false,
+		},
+		{
+			name:      "unknown devnet",
+			namespace: "default",
+			devnetRef: "nonexistent",
+			spec:      &v1.UpgradeSpec{DevnetRef: "nonexistent", UpgradeName: "v2"},
+			wantErr:   true,
+			field:     "spec.devnet_ref",
+		},
+		{
+			name:      "empty devnet ref is ok",
+			namespace: "default",
+			devnetRef: "",
+			spec:      &v1.UpgradeSpec{DevnetRef: "", UpgradeName: "v2"},
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.ValidateUpgradeReferences(ctx, tt.namespace, tt.spec)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUpgradeReferences() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && tt.field != "" {
+				if ve, ok := err.(*ValidationError); ok {
+					if ve.Field != tt.field {
+						t.Errorf("ValidateUpgradeReferences() field = %v, want %v", ve.Field, tt.field)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestReferenceValidator_NodeReferences(t *testing.T) {
+	store := newMockStore()
+	store.devnets["default/my-devnet"] = &types.Devnet{
+		Metadata: types.ResourceMeta{Name: "my-devnet", Namespace: "default"},
+		Spec:     types.DevnetSpec{Plugin: "stable"},
+	}
+	networkSvc := newMockNetworkService()
+	v := NewReferenceValidator(store, networkSvc)
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		namespace  string
+		devnetName string
+		index      int
+		wantErr    bool
+		field      string
+	}{
+		{
+			name:       "valid devnet ref",
+			namespace:  "default",
+			devnetName: "my-devnet",
+			index:      0,
+			wantErr:    false,
+		},
+		{
+			name:       "unknown devnet",
+			namespace:  "default",
+			devnetName: "nonexistent",
+			index:      0,
+			wantErr:    true,
+			field:      "devnet_name",
+		},
+		{
+			name:       "empty devnet name is ok",
+			namespace:  "default",
+			devnetName: "",
+			index:      0,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.ValidateNodeReferences(ctx, tt.namespace, tt.devnetName, tt.index)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateNodeReferences() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && tt.field != "" {
+				if ve, ok := err.(*ValidationError); ok {
+					if ve.Field != tt.field {
+						t.Errorf("ValidateNodeReferences() field = %v, want %v", ve.Field, tt.field)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/daemon/server/ante/spec_validator.go
+++ b/internal/daemon/server/ante/spec_validator.go
@@ -1,0 +1,96 @@
+// internal/daemon/server/ante/spec_validator.go
+package ante
+
+import (
+	"context"
+
+	v1 "github.com/altuslabsxyz/devnet-builder/api/proto/gen/v1"
+)
+
+const (
+	// MaxValidators is the maximum number of validators allowed per devnet.
+	// Limited to 4 to keep local development resources manageable while
+	// still allowing realistic consensus testing scenarios.
+	MaxValidators = 4
+
+	// MaxFullNodes is the maximum number of full nodes allowed per devnet.
+	// Limited to 10 to prevent excessive resource consumption on development
+	// machines while allowing meaningful network topology testing.
+	MaxFullNodes = 10
+)
+
+// SpecValidator validates business rules and constraints.
+type SpecValidator interface {
+	ValidateDevnetSpec(ctx context.Context, spec *v1.DevnetSpec) error
+	ValidateUpgradeSpec(ctx context.Context, spec *v1.UpgradeSpec) error
+}
+
+type specValidator struct{}
+
+func NewSpecValidator() SpecValidator {
+	return &specValidator{}
+}
+
+func (v *specValidator) ValidateDevnetSpec(ctx context.Context, spec *v1.DevnetSpec) error {
+	if spec == nil {
+		return nil
+	}
+
+	var errs []*ValidationError
+
+	// Mode validation
+	if spec.Mode != "" && spec.Mode != "docker" && spec.Mode != "local" {
+		errs = append(errs, &ValidationError{
+			Field:   "spec.mode",
+			Code:    CodeInvalidValue,
+			Message: "mode must be 'docker' or 'local'",
+		})
+	}
+
+	// Validators count
+	if spec.Validators > MaxValidators {
+		errs = append(errs, &ValidationError{
+			Field:   "spec.validators",
+			Code:    CodeInvalidRange,
+			Message: "validators must be between 0 and 4",
+		})
+	}
+
+	// FullNodes count
+	if spec.FullNodes > MaxFullNodes {
+		errs = append(errs, &ValidationError{
+			Field:   "spec.full_nodes",
+			Code:    CodeInvalidRange,
+			Message: "full_nodes must be between 0 and 10",
+		})
+	}
+
+	// NetworkType validation
+	if spec.NetworkType != "" && spec.NetworkType != "mainnet" && spec.NetworkType != "testnet" {
+		errs = append(errs, &ValidationError{
+			Field:   "spec.network_type",
+			Code:    CodeInvalidValue,
+			Message: "network_type must be 'mainnet' or 'testnet'",
+		})
+	}
+
+	return toError(errs)
+}
+
+func (v *specValidator) ValidateUpgradeSpec(ctx context.Context, spec *v1.UpgradeSpec) error {
+	if spec == nil {
+		return nil
+	}
+
+	var errs []*ValidationError
+
+	if spec.TargetHeight < 0 {
+		errs = append(errs, &ValidationError{
+			Field:   "spec.target_height",
+			Code:    CodeInvalidRange,
+			Message: "target_height must be non-negative",
+		})
+	}
+
+	return toError(errs)
+}

--- a/internal/daemon/server/ante/spec_validator_test.go
+++ b/internal/daemon/server/ante/spec_validator_test.go
@@ -1,0 +1,110 @@
+// internal/daemon/server/ante/spec_validator_test.go
+package ante
+
+import (
+	"context"
+	"testing"
+
+	v1 "github.com/altuslabsxyz/devnet-builder/api/proto/gen/v1"
+)
+
+func TestSpecValidator_DevnetSpec(t *testing.T) {
+	v := NewSpecValidator()
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		spec    *v1.DevnetSpec
+		wantErr bool
+		field   string
+	}{
+		{
+			name:    "valid spec",
+			spec:    &v1.DevnetSpec{Plugin: "stable", Mode: "docker", Validators: 2},
+			wantErr: false,
+		},
+		{
+			name:    "nil spec is ok (field validator handles)",
+			spec:    nil,
+			wantErr: false,
+		},
+		{
+			name:    "invalid mode",
+			spec:    &v1.DevnetSpec{Plugin: "stable", Mode: "invalid"},
+			wantErr: true,
+			field:   "spec.mode",
+		},
+		{
+			name:    "validators too high",
+			spec:    &v1.DevnetSpec{Plugin: "stable", Mode: "docker", Validators: 10},
+			wantErr: true,
+			field:   "spec.validators",
+		},
+		{
+			name:    "fullnodes too high",
+			spec:    &v1.DevnetSpec{Plugin: "stable", Mode: "docker", FullNodes: 20},
+			wantErr: true,
+			field:   "spec.full_nodes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.ValidateDevnetSpec(ctx, tt.spec)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateDevnetSpec() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && tt.field != "" {
+				ve, ok := err.(*ValidationError)
+				if !ok {
+					me, ok := err.(*MultiValidationError)
+					if ok && len(me.Errors) > 0 {
+						ve = me.Errors[0]
+					} else {
+						t.Errorf("expected *ValidationError, got %T", err)
+						return
+					}
+				}
+				if ve.Field != tt.field {
+					t.Errorf("error field = %s, want %s", ve.Field, tt.field)
+				}
+			}
+		})
+	}
+}
+
+func TestSpecValidator_UpgradeSpec(t *testing.T) {
+	v := NewSpecValidator()
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		spec    *v1.UpgradeSpec
+		wantErr bool
+	}{
+		{
+			name:    "valid spec",
+			spec:    &v1.UpgradeSpec{DevnetRef: "my-devnet", UpgradeName: "v2", TargetHeight: 100},
+			wantErr: false,
+		},
+		{
+			name:    "nil spec is ok",
+			spec:    nil,
+			wantErr: false,
+		},
+		{
+			name:    "negative height",
+			spec:    &v1.UpgradeSpec{DevnetRef: "my-devnet", UpgradeName: "v2", TargetHeight: -1},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.ValidateUpgradeSpec(ctx, tt.spec)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUpgradeSpec() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/daemon/server/server.go
+++ b/internal/daemon/server/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/altuslabsxyz/devnet-builder/internal/daemon/controller"
 	"github.com/altuslabsxyz/devnet-builder/internal/daemon/provisioner"
 	"github.com/altuslabsxyz/devnet-builder/internal/daemon/runtime"
+	"github.com/altuslabsxyz/devnet-builder/internal/daemon/server/ante"
 	"github.com/altuslabsxyz/devnet-builder/internal/daemon/store"
 	"github.com/altuslabsxyz/devnet-builder/internal/daemon/upgrader"
 	"google.golang.org/grpc"
@@ -203,16 +204,24 @@ func New(config *Config) (*Server, error) {
 	// Create gRPC server
 	grpcServer := grpc.NewServer()
 
+	// Create network service first (needed by ante handler)
+	githubFactory := NewDefaultGitHubClientFactory(config.DataDir, logger)
+	networkSvc := NewNetworkService(githubFactory)
+	networkSvc.SetLogger(logger)
+
+	// Create ante handler for request validation
+	anteHandler := ante.New(st, networkSvc)
+
 	// Register services
-	devnetSvc := NewDevnetService(st, mgr)
+	devnetSvc := NewDevnetServiceWithAnte(st, mgr, anteHandler)
 	devnetSvc.SetLogger(logger)
 	v1.RegisterDevnetServiceServer(grpcServer, devnetSvc)
 
-	nodeSvc := NewNodeService(st, mgr, nodeRuntime)
+	nodeSvc := NewNodeServiceWithAnte(st, mgr, nodeRuntime, anteHandler)
 	nodeSvc.SetLogger(logger)
 	v1.RegisterNodeServiceServer(grpcServer, nodeSvc)
 
-	upgradeSvc := NewUpgradeService(st, mgr)
+	upgradeSvc := NewUpgradeServiceWithAnte(st, mgr, anteHandler)
 	upgradeSvc.SetLogger(logger)
 	v1.RegisterUpgradeServiceServer(grpcServer, upgradeSvc)
 
@@ -220,9 +229,6 @@ func New(config *Config) (*Server, error) {
 	txSvc.SetLogger(logger)
 	v1.RegisterTransactionServiceServer(grpcServer, txSvc)
 
-	githubFactory := NewDefaultGitHubClientFactory(config.DataDir, logger)
-	networkSvc := NewNetworkService(githubFactory)
-	networkSvc.SetLogger(logger)
 	v1.RegisterNetworkServiceServer(grpcServer, networkSvc)
 
 	return &Server{


### PR DESCRIPTION
## Summary
- Add ante handler pattern for validating gRPC requests before service logic
- Three-layer validation: field → spec → reference
- Integrate with DevnetService, UpgradeService, and NodeService

## Test plan
- [x] All ante package tests pass
- [x] All server package tests pass
- [x] Build successful