### PR TITLE
fix: remove duplicate generation increment causing OCC conflicts

### DIFF
--- a/internal/daemon/server/devnet_service.go
+++ b/internal/daemon/server/devnet_service.go
@@ -330,8 +330,8 @@ func (s *DevnetService) ApplyDevnet(ctx context.Context, req *v1.ApplyDevnetRequ
 	if req.Annotations != nil {
 		existing.Metadata.Annotations = req.Annotations
 	}
-	existing.Metadata.UpdatedAt = time.Now()
-	existing.Metadata.Generation++
+	// Note: Generation is incremented by the store layer after conflict check passes.
+	// Do not increment here - that would cause the conflict check to always fail.
 
 	err = s.store.UpdateDevnet(ctx, existing)
 	if err != nil {
@@ -385,8 +385,8 @@ func (s *DevnetService) UpdateDevnet(ctx context.Context, req *v1.UpdateDevnetRe
 	if req.Annotations != nil {
 		existing.Metadata.Annotations = req.Annotations
 	}
-	existing.Metadata.UpdatedAt = time.Now()
-	existing.Metadata.Generation++
+	// Note: Generation is incremented by the store layer after conflict check passes.
+	// Do not increment here - that would cause the conflict check to always fail.
 
 	err = s.store.UpdateDevnet(ctx, existing)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Fix generation mismatch errors on devnet apply/update operations
- Service layer was pre-incrementing generation before store update, but store also increments after conflict check
- This caused the conflict check to always fail when concurrent updates occurred

## Test plan
- [ ] Run `dvb apply -f devnet.yaml` on a running devnet
- [ ] Verify no generation mismatch errors