### PR TITLE
fix: add validation for empty RPC genesis

### DIFF
--- a/internal/infrastructure/stateexport/adapter.go
+++ b/internal/infrastructure/stateexport/adapter.go
@@ -161,6 +161,12 @@ func (a *Adapter) PrepareForExport(ctx context.Context, homeDir string, rpcGenes
 	default:
 	}
 
+	// Validate rpcGenesis is not empty
+	// The export command requires a valid genesis.json to read chain parameters
+	if len(rpcGenesis) == 0 {
+		return fmt.Errorf("rpcGenesis is empty: cannot prepare for export without valid genesis data from RPC")
+	}
+
 	// Ensure config directory exists
 	configDir := filepath.Join(homeDir, "config")
 	if err := os.MkdirAll(configDir, 0755); err != nil {
@@ -173,7 +179,7 @@ func (a *Adapter) PrepareForExport(ctx context.Context, homeDir string, rpcGenes
 	if err := os.WriteFile(genesisPath, rpcGenesis, 0644); err != nil {
 		return fmt.Errorf("failed to write genesis: %w", err)
 	}
-	a.logger.Debug("Wrote RPC genesis to %s", genesisPath)
+	a.logger.Debug("Wrote RPC genesis to %s (%d bytes)", genesisPath, len(rpcGenesis))
 
 	// Ensure data directory exists
 	dataDir := filepath.Join(homeDir, "data")


### PR DESCRIPTION
## Summary
- Add validation for empty RPC genesis in snapshot-based genesis forking
- Return clear error messages when RPC URL is missing or genesis fetch fails
- Prevent cryptic JSON unmarshalling errors from empty genesis files

## Test plan
- [ ] Test snapshot forking with valid RPC endpoint
- [ ] Verify error message when plugin returns empty RPC URL
- [ ] Verify error message when RPC fetch fails