### PR TITLE
fix: validate RPC genesis before export

### DIFF
--- a/internal/daemon/provisioner/genesis_forker.go
+++ b/internal/daemon/provisioner/genesis_forker.go
@@ -188,15 +188,32 @@ func (f *GenesisForker) forkFromSnapshotInfra(ctx context.Context, opts ports.Fo
 	}
 
 	// First, fetch RPC genesis for chain params
+	// The RPC genesis is required for the export command to read chain parameters
 	rpcURL := opts.Source.RPCURL
 	if rpcURL == "" && f.config.PluginGenesis != nil {
 		rpcURL = f.config.PluginGenesis.GetRPCEndpoint(opts.Source.NetworkType)
 	}
 
-	var rpcGenesis []byte
-	if rpcURL != "" && f.config.GenesisFetcher != nil {
-		rpcGenesis, _ = f.config.GenesisFetcher.FetchFromRPC(ctx, rpcURL)
+	if rpcURL == "" {
+		return nil, fmt.Errorf("no RPC URL available for network type %q: plugin must implement GetRPCEndpoint() or provide RPCURL in source options", opts.Source.NetworkType)
 	}
+
+	if f.config.GenesisFetcher == nil {
+		return nil, fmt.Errorf("genesis fetcher not configured: cannot fetch RPC genesis from %s", rpcURL)
+	}
+
+	f.logger.Debug("fetching RPC genesis for chain params", "rpcURL", rpcURL)
+
+	rpcGenesis, err := f.config.GenesisFetcher.FetchFromRPC(ctx, rpcURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch RPC genesis from %s: %w", rpcURL, err)
+	}
+
+	if len(rpcGenesis) == 0 {
+		return nil, fmt.Errorf("RPC genesis is empty: fetched from %s but received no data", rpcURL)
+	}
+
+	f.logger.Debug("RPC genesis fetched successfully", "size", len(rpcGenesis))
 
 	// Export genesis from snapshot
 	exportOpts := ports.StateExportOptions{

--- a/internal/infrastructure/stateexport/adapter.go
+++ b/internal/infrastructure/stateexport/adapter.go
@@ -161,6 +161,12 @@ func (a *Adapter) PrepareForExport(ctx context.Context, homeDir string, rpcGenes
 	default:
 	}
 
+	// Validate rpcGenesis is not empty
+	// The export command requires a valid genesis.json to read chain parameters
+	if len(rpcGenesis) == 0 {
+		return fmt.Errorf("rpcGenesis is empty: cannot prepare for export without valid genesis data from RPC")
+	}
+
 	// Ensure config directory exists
 	configDir := filepath.Join(homeDir, "config")
 	if err := os.MkdirAll(configDir, 0755); err != nil {
@@ -173,7 +179,7 @@ func (a *Adapter) PrepareForExport(ctx context.Context, homeDir string, rpcGenes
 	if err := os.WriteFile(genesisPath, rpcGenesis, 0644); err != nil {
 		return fmt.Errorf("failed to write genesis: %w", err)
 	}
-	a.logger.Debug("Wrote RPC genesis to %s", genesisPath)
+	a.logger.Debug("Wrote RPC genesis to %s (%d bytes)", genesisPath, len(rpcGenesis))
 
 	// Ensure data directory exists
 	dataDir := filepath.Join(homeDir, "data")


### PR DESCRIPTION
## Summary
- Add validation for empty RPC genesis in snapshot-based genesis forking
- Return clear error messages when RPC URL is missing or genesis fetch fails

## Test plan
- [ ] Test snapshot forking with valid RPC endpoint
- [ ] Verify error message when plugin returns empty RPC URL