### PR TITLE
fix: truncate long event messages in describe output

### DIFF
--- a/cmd/dvb/describe_test.go
+++ b/cmd/dvb/describe_test.go
@@ -72,3 +72,76 @@ func TestFormatDescribeOutput(t *testing.T) {
 		t.Error("missing condition reason")
 	}
 }
+
+func TestFormatDescribeOutputWithLongEventMessage(t *testing.T) {
+	// Create a very long multi-line error message similar to real stack traces
+	longMessage := `Provisioning failed: orchestrator execution failed: forking phase failed: genesis fork failed: failed to fetch genesis: failed to export genesis from snapshot: state export export error: export failed: exit status 2
+Output: 10:48AM INF Upgrading IAVL storage for faster queries + execution on live state. This may take a while commit=436F6D6D697449447B5B5D3A307D module=server store_key="KVStoreKey{0xc0047f3c10, precisebank}" version=1
+10:48AM INF Upgrading IAVL storage for faster queries + execution on live state. This may take a while commit=436F6D6D697449447B5B5D3A307D module=server store_key="KVStoreKey{0xc0047f3b70, staking}" version=1
+panic: collections: not found: key 'no_key' of type github.com/cosmos/gogoproto/cosmos.distribution.v1beta1.FeePool`
+
+	devnet := &v1.Devnet{
+		Metadata: &v1.DevnetMetadata{
+			Name:      "test-devnet",
+			CreatedAt: timestamppb.New(time.Now().Add(-1 * time.Hour)),
+		},
+		Spec: &v1.DevnetSpec{
+			Plugin:     "stable",
+			Mode:       "local",
+			Validators: 1,
+		},
+		Status: &v1.DevnetStatus{
+			Phase:      "Degraded",
+			Nodes:      1,
+			ReadyNodes: 0,
+			Message:    "No nodes healthy",
+			Events: []*v1.Event{
+				{
+					Timestamp: timestamppb.Now(),
+					Type:      "Warning",
+					Reason:    "ProvisioningFailed",
+					Message:   longMessage,
+					Component: "devnet-controller",
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	formatDescribeOutput(&buf, devnet, nil, true, nil)
+	output := buf.String()
+
+	// Verify the message is truncated
+	lines := bytes.Split([]byte(output), []byte("\n"))
+	var eventLine string
+	for _, line := range lines {
+		if bytes.Contains(line, []byte("ProvisioningFailed")) {
+			eventLine = string(line)
+			break
+		}
+	}
+
+	if eventLine == "" {
+		t.Fatal("event line not found in output")
+	}
+
+	// The message should be truncated to ~120 chars
+	if len(eventLine) > 300 {
+		t.Errorf("event line too long: %d chars, expected < 300", len(eventLine))
+	}
+
+	// Should contain truncation indicator
+	if !bytes.Contains([]byte(eventLine), []byte("...")) {
+		t.Error("expected truncation indicator '...' in long message")
+	}
+
+	// Should not contain newlines in the message portion
+	msgStart := bytes.Index([]byte(eventLine), []byte("ProvisioningFailed"))
+	if msgStart >= 0 {
+		msgPortion := eventLine[msgStart:]
+		// The original message has literal "\n" which should not appear in output
+		if bytes.Contains([]byte(msgPortion), []byte("Output:")) && bytes.Count([]byte(msgPortion), []byte("\n")) > 0 {
+			t.Error("event message should not contain literal newlines")
+		}
+	}
+}

--- a/cmd/dvb/main.go
+++ b/cmd/dvb/main.go
@@ -676,7 +676,20 @@ func formatDescribeOutput(w io.Writer, d *v1.Devnet, nodes []*v1.Node, pluginAva
 			if e.Timestamp != nil {
 				age = time.Since(e.Timestamp.AsTime()).Round(time.Second).String()
 			}
-			fmt.Fprintf(w, "  %-8s %-20s %-20s %s\n", eventType, e.Reason, age, e.Message)
+			// Truncate and clean message for readability
+			msg := e.Message
+			// Replace newlines and multiple spaces with single space
+			msg = strings.ReplaceAll(msg, "\n", " ")
+			msg = strings.ReplaceAll(msg, "\r", " ")
+			// Collapse multiple spaces
+			for strings.Contains(msg, "  ") {
+				msg = strings.ReplaceAll(msg, "  ", " ")
+			}
+			// Truncate to reasonable length
+			if len(msg) > 120 {
+				msg = msg[:117] + "..."
+			}
+			fmt.Fprintf(w, "  %-8s %-20s %-20s %s\n", eventType, e.Reason, age, msg)
 		}
 	}
 


### PR DESCRIPTION
## Summary
Reduces verbosity of `dvb describe` command output by truncating long event messages.

## Changes
- Event messages now limited to 120 characters with "..." indicator
- Newlines and carriage returns replaced with spaces
- Multiple consecutive spaces collapsed to single space
- Added test coverage for long multi-line error messages

## Impact
Event messages with stack traces and long error outputs now fit on a single line, improving readability while preserving the most important error context.