### PR TITLE
fix: ensure --overwrite flag in node init commands

### DIFF
--- a/internal/daemon/server/wiring_test.go
+++ b/internal/daemon/server/wiring_test.go
@@ -445,3 +445,48 @@ func splitWords(s string) []string {
 	}
 	return words
 }
+
+// =============================================================================
+// ensureOverwriteFlag Tests
+// =============================================================================
+
+func TestEnsureOverwriteFlag(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "adds flag when missing",
+			input:    []string{"init", "validator0", "--chain-id", "test-1", "--home", "/tmp/node"},
+			expected: []string{"init", "validator0", "--chain-id", "test-1", "--home", "/tmp/node", "--overwrite"},
+		},
+		{
+			name:     "does not duplicate --overwrite",
+			input:    []string{"init", "validator0", "--chain-id", "test-1", "--home", "/tmp/node", "--overwrite"},
+			expected: []string{"init", "validator0", "--chain-id", "test-1", "--home", "/tmp/node", "--overwrite"},
+		},
+		{
+			name:     "does not duplicate -o short form",
+			input:    []string{"init", "validator0", "--chain-id", "test-1", "-o", "--home", "/tmp/node"},
+			expected: []string{"init", "validator0", "--chain-id", "test-1", "-o", "--home", "/tmp/node"},
+		},
+		{
+			name:     "handles empty args",
+			input:    []string{},
+			expected: []string{"--overwrite"},
+		},
+		{
+			name:     "handles nil args",
+			input:    nil,
+			expected: []string{"--overwrite"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ensureOverwriteFlag(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add defensive `ensureOverwriteFlag()` to always include `--overwrite` in init commands
- Fixes provisioning failure when genesis.json exists from previous runs

## Problem
The `stable` plugin's `InitCommand()` returns args without `--overwrite`, causing `stabled init` to fail when leftover state exists.

## Solution
Add a defensive layer in `nodeInitializerAdapter.Initialize()` that ensures `--overwrite` is always present regardless of plugin behavior.

## Test plan
- [x] Added unit tests for `ensureOverwriteFlag()`
- [x] All existing tests pass