### PR TITLE
feat: add dvb status command and smart error suggestions

### DIFF
--- a/cmd/dvb/logs.go
+++ b/cmd/dvb/logs.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/altuslabsxyz/devnet-builder/internal/client"
-	"github.com/altuslabsxyz/devnet-builder/internal/dvbcontext"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
@@ -87,10 +86,12 @@ Examples:
 				nodeArg = args[1]
 			}
 
-			_, devnetName, err := dvbcontext.Resolve(explicitDevnet, "", currentContext)
+			_, devnetName, err := resolveWithSuggestions(explicitDevnet, "")
 			if err != nil {
 				return err
 			}
+
+			printContextHeader(explicitDevnet, currentContext)
 
 			opts.devnet = devnetName
 			opts.node = nodeArg

--- a/cmd/dvb/node.go
+++ b/cmd/dvb/node.go
@@ -15,7 +15,6 @@ import (
 	v1 "github.com/altuslabsxyz/devnet-builder/api/proto/gen/v1"
 	"github.com/altuslabsxyz/devnet-builder/internal/client"
 	"github.com/altuslabsxyz/devnet-builder/internal/daemon/provisioner"
-	"github.com/altuslabsxyz/devnet-builder/internal/dvbcontext"
 	"github.com/altuslabsxyz/devnet-builder/internal/plugin/cosmos"
 	"github.com/altuslabsxyz/devnet-builder/internal/plugin/types"
 	"github.com/fatih/color"
@@ -107,11 +106,16 @@ Examples:
 				explicitDevnet = args[0]
 			}
 
-			ns, devnetName, err := dvbcontext.Resolve(explicitDevnet, opts.namespace, currentContext)
+			ns, devnetName, err := resolveWithSuggestions(explicitDevnet, opts.namespace)
 			if err != nil {
 				return err
 			}
 			opts.namespace = ns
+
+			// Print context header (skip for watch mode as it clears screen)
+			if !opts.watch {
+				printContextHeader(explicitDevnet, currentContext)
+			}
 
 			if opts.watch {
 				return runNodeListWatch(cmd.Context(), devnetName, opts)
@@ -364,7 +368,7 @@ Examples:
 				indexArg = args[1]
 			}
 
-			ns, devnetName, err := dvbcontext.Resolve(explicitDevnet, namespace, currentContext)
+			ns, devnetName, err := resolveWithSuggestions(explicitDevnet, namespace)
 			if err != nil {
 				return err
 			}
@@ -435,7 +439,7 @@ Examples:
 				indexArg = args[1]
 			}
 
-			_, devnetName, err := dvbcontext.Resolve(explicitDevnet, namespace, currentContext)
+			_, devnetName, err := resolveWithSuggestions(explicitDevnet, namespace)
 			if err != nil {
 				return err
 			}
@@ -500,7 +504,7 @@ Examples:
 				indexArg = args[1]
 			}
 
-			_, devnetName, err := dvbcontext.Resolve(explicitDevnet, namespace, currentContext)
+			_, devnetName, err := resolveWithSuggestions(explicitDevnet, namespace)
 			if err != nil {
 				return err
 			}
@@ -584,7 +588,7 @@ Examples:
 				indexArg = args[1]
 			}
 
-			ns, devnetName, err := dvbcontext.Resolve(explicitDevnet, namespace, currentContext)
+			ns, devnetName, err := resolveWithSuggestions(explicitDevnet, namespace)
 			if err != nil {
 				return err
 			}
@@ -643,7 +647,7 @@ Examples:
 				indexArg = args[1]
 			}
 
-			ns, devnetName, err := dvbcontext.Resolve(explicitDevnet, namespace, currentContext)
+			ns, devnetName, err := resolveWithSuggestions(explicitDevnet, namespace)
 			if err != nil {
 				return err
 			}
@@ -702,7 +706,7 @@ Examples:
 				indexArg = args[1]
 			}
 
-			ns, devnetName, err := dvbcontext.Resolve(explicitDevnet, namespace, currentContext)
+			ns, devnetName, err := resolveWithSuggestions(explicitDevnet, namespace)
 			if err != nil {
 				return err
 			}
@@ -805,7 +809,7 @@ Examples:
 				return fmt.Errorf("missing node index")
 			}
 
-			_, devnetName, err := dvbcontext.Resolve(explicitDevnet, namespace, currentContext)
+			_, devnetName, err := resolveWithSuggestions(explicitDevnet, namespace)
 			if err != nil {
 				return err
 			}

--- a/cmd/dvb/status.go
+++ b/cmd/dvb/status.go
@@ -1,0 +1,317 @@
+// cmd/dvb/status.go
+package main
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	v1 "github.com/altuslabsxyz/devnet-builder/api/proto/gen/v1"
+	"github.com/altuslabsxyz/devnet-builder/internal/client"
+	"github.com/altuslabsxyz/devnet-builder/internal/dvbcontext"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+func newStatusCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show current devnet status",
+		Long: `Show the current devnet status based on context.
+
+When context is set (via dvb use <devnet>), shows detailed status including:
+  - Devnet phase (Running/Stopped/etc.)
+  - Node list with status
+  - Quick actions available
+
+When no context is set, shows available devnets and how to set context.
+
+Examples:
+  # Show status of current context
+  dvb status
+
+  # Set context first, then show status
+  dvb use my-devnet
+  dvb status`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStatus(cmd)
+		},
+	}
+
+	return cmd
+}
+
+func runStatus(cmd *cobra.Command) error {
+	// Load context
+	ctx, err := dvbcontext.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load context: %w", err)
+	}
+
+	// Check daemon status
+	daemonRunning := client.IsDaemonRunning()
+
+	// Case 1: Daemon not running
+	if !daemonRunning {
+		return printStatusDaemonNotRunning(ctx)
+	}
+
+	// Case 2: No context set
+	if ctx == nil {
+		return printStatusNoContext(cmd)
+	}
+
+	// Case 3: Context set and daemon running
+	return printStatusWithContext(cmd, ctx)
+}
+
+// printStatusDaemonNotRunning handles the case when daemon is not running
+func printStatusDaemonNotRunning(ctx *dvbcontext.Context) error {
+	// Show context if set
+	if ctx != nil {
+		fmt.Print("Context: ")
+		if ctx.Namespace == "default" {
+			fmt.Println(ctx.Devnet)
+		} else {
+			fmt.Printf("%s/%s\n", ctx.Namespace, ctx.Devnet)
+		}
+		fmt.Println()
+	} else {
+		fmt.Println("Context: (not set)")
+		fmt.Println()
+	}
+
+	color.Yellow("Daemon: Not running")
+	fmt.Println()
+	fmt.Println("Start the daemon with:")
+	fmt.Println("  devnetd &")
+	fmt.Println()
+	fmt.Println("Or run in foreground:")
+	fmt.Println("  devnetd")
+
+	return nil
+}
+
+// printStatusNoContext handles the case when no context is set
+func printStatusNoContext(cmd *cobra.Command) error {
+	fmt.Println("Context: (not set)")
+	fmt.Println()
+
+	// List available devnets
+	devnets, err := daemonClient.ListDevnets(cmd.Context(), "")
+	if err != nil {
+		return fmt.Errorf("failed to list devnets: %w", err)
+	}
+
+	if len(devnets) == 0 {
+		fmt.Println("No devnets found.")
+		fmt.Println()
+		fmt.Println("Create a devnet with:")
+		fmt.Println("  dvb provision -i")
+		return nil
+	}
+
+	fmt.Println("Available devnets:")
+	fmt.Println()
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "  NAME\tSTATUS\tNODES")
+	for _, d := range devnets {
+		name := d.Metadata.Name
+		if d.Metadata.Namespace != "default" {
+			name = fmt.Sprintf("%s/%s", d.Metadata.Namespace, d.Metadata.Name)
+		}
+		phase := formatPhase(d.Status.Phase)
+		nodes := fmt.Sprintf("%d/%d ready", d.Status.ReadyNodes, d.Status.Nodes)
+		fmt.Fprintf(w, "  %s\t%s\t%s\n", name, phase, nodes)
+	}
+	w.Flush()
+
+	fmt.Println()
+	fmt.Println("Set context with:")
+	fmt.Println("  dvb use <devnet>")
+
+	return nil
+}
+
+// printStatusWithContext handles the case when context is set and daemon is running
+func printStatusWithContext(cmd *cobra.Command, ctx *dvbcontext.Context) error {
+	// Print context header
+	fmt.Print("Context: ")
+	if ctx.Namespace == "default" {
+		color.New(color.Bold).Println(ctx.Devnet)
+	} else {
+		color.New(color.Bold).Printf("%s/%s\n", ctx.Namespace, ctx.Devnet)
+	}
+	fmt.Println()
+
+	// Get devnet details
+	devnet, err := daemonClient.GetDevnet(cmd.Context(), ctx.Namespace, ctx.Devnet)
+	if err != nil {
+		color.Red("Error: devnet not found")
+		fmt.Println()
+		fmt.Println("The devnet in your context no longer exists.")
+		fmt.Println("Clear context with: dvb use -")
+		fmt.Println("Or set a new context: dvb use <devnet>")
+		return nil
+	}
+
+	// Print devnet status
+	printDevnetStatus(devnet)
+
+	// Get and print nodes
+	nodes, err := daemonClient.ListNodes(cmd.Context(), ctx.Namespace, ctx.Devnet)
+	if err == nil && len(nodes) > 0 {
+		fmt.Println()
+		printNodesSummary(nodes)
+	}
+
+	// Print quick actions
+	fmt.Println()
+	printQuickActions(devnet)
+
+	return nil
+}
+
+// printDevnetStatus prints the devnet status section
+func printDevnetStatus(d *v1.Devnet) {
+	if d.Status == nil {
+		d.Status = &v1.DevnetStatus{}
+	}
+
+	// Status line with icon
+	phase := d.Status.Phase
+	switch phase {
+	case "Running":
+		color.Green("Status: Running")
+	case "Stopped":
+		color.White("Status: Stopped")
+	case "Pending", "Provisioning":
+		color.Yellow("Status: %s", phase)
+	case "Degraded":
+		color.Red("Status: Degraded")
+	default:
+		fmt.Printf("Status: %s\n", phase)
+	}
+
+	// Show additional info
+	if d.Status.CurrentHeight > 0 {
+		fmt.Printf("Height: %d\n", d.Status.CurrentHeight)
+	}
+
+	// Show age
+	if d.Metadata != nil && d.Metadata.CreatedAt != nil {
+		age := time.Since(d.Metadata.CreatedAt.AsTime()).Round(time.Second)
+		fmt.Printf("Age:    %s\n", formatAge(age))
+	}
+
+	// Show plugin/network info
+	if d.Spec != nil && d.Spec.Plugin != "" {
+		fmt.Printf("Plugin: %s\n", d.Spec.Plugin)
+	}
+}
+
+// printNodesSummary prints a compact node status table
+func printNodesSummary(nodes []*v1.Node) {
+	fmt.Println("Nodes:")
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "  INDEX\tROLE\tSTATUS\tHEIGHT")
+
+	for _, n := range nodes {
+		phase := n.Status.Phase
+		var statusStr string
+		switch phase {
+		case "Running":
+			statusStr = color.GreenString("Running")
+		case "Stopped":
+			statusStr = color.WhiteString("Stopped")
+		case "Pending", "Starting":
+			statusStr = color.YellowString(phase)
+		case "Crashed":
+			statusStr = color.RedString("Crashed")
+		default:
+			statusStr = phase
+		}
+
+		height := "-"
+		if n.Status.BlockHeight > 0 {
+			height = fmt.Sprintf("%d", n.Status.BlockHeight)
+		}
+
+		fmt.Fprintf(w, "  %d\t%s\t%s\t%s\n",
+			n.Metadata.Index,
+			n.Spec.Role,
+			statusStr,
+			height,
+		)
+	}
+	w.Flush()
+}
+
+// printQuickActions prints suggested actions based on devnet state
+func printQuickActions(d *v1.Devnet) {
+	fmt.Println("Quick actions:")
+
+	switch d.Status.Phase {
+	case "Running":
+		fmt.Println("  dvb stop          # Stop the devnet")
+		fmt.Println("  dvb logs -f       # Follow logs")
+		fmt.Println("  dvb describe      # Show detailed info")
+		fmt.Println("  dvb node list     # List all nodes")
+	case "Stopped":
+		fmt.Println("  dvb start         # Start the devnet")
+		fmt.Println("  dvb describe      # Show detailed info")
+		fmt.Println("  dvb delete        # Delete the devnet")
+	case "Pending", "Provisioning":
+		fmt.Println("  dvb describe      # Show detailed status")
+		fmt.Println("  dvb daemon logs   # Check daemon logs")
+	case "Degraded":
+		fmt.Println("  dvb describe      # Show detailed status and troubleshooting")
+		fmt.Println("  dvb daemon logs   # Check daemon logs for errors")
+		fmt.Println("  dvb delete        # Delete and recreate")
+	default:
+		fmt.Println("  dvb describe      # Show detailed info")
+	}
+}
+
+// formatPhase returns a colored phase string
+func formatPhase(phase string) string {
+	switch phase {
+	case "Running":
+		return color.GreenString("Running")
+	case "Stopped":
+		return color.WhiteString("Stopped")
+	case "Pending", "Provisioning":
+		return color.YellowString(phase)
+	case "Degraded":
+		return color.RedString("Degraded")
+	default:
+		return phase
+	}
+}
+
+// formatAge formats a duration into a human-readable age string
+func formatAge(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	if d < 24*time.Hour {
+		hours := int(d.Hours())
+		mins := int(d.Minutes()) % 60
+		if mins > 0 {
+			return fmt.Sprintf("%dh%dm", hours, mins)
+		}
+		return fmt.Sprintf("%dh", hours)
+	}
+	days := int(d.Hours() / 24)
+	hours := int(d.Hours()) % 24
+	if hours > 0 {
+		return fmt.Sprintf("%dd%dh", days, hours)
+	}
+	return fmt.Sprintf("%dd", days)
+}

--- a/internal/dvbcontext/resolve.go
+++ b/internal/dvbcontext/resolve.go
@@ -5,6 +5,31 @@ import "errors"
 // ErrNoDevnet is returned when no devnet is specified and no context is set.
 var ErrNoDevnet = errors.New("no devnet specified and no context set. Run 'dvb use <devnet>' to set context")
 
+// NoDevnetError is an error that can carry suggestions for available devnets.
+// It satisfies errors.Is(err, ErrNoDevnet) for backward compatibility.
+type NoDevnetError struct {
+	Suggestion string
+}
+
+// Error returns the error message with optional suggestions.
+func (e *NoDevnetError) Error() string {
+	msg := "no devnet specified and no context set"
+	if e.Suggestion != "" {
+		return msg + "\n\n" + e.Suggestion
+	}
+	return msg + ". Run 'dvb use <devnet>' to set context"
+}
+
+// Is allows errors.Is(err, ErrNoDevnet) to return true.
+func (e *NoDevnetError) Is(target error) bool {
+	return target == ErrNoDevnet
+}
+
+// NewNoDevnetError creates a NoDevnetError with the given suggestion.
+func NewNoDevnetError(suggestion string) *NoDevnetError {
+	return &NoDevnetError{Suggestion: suggestion}
+}
+
 // Resolve determines the namespace and devnet to use based on:
 // 1. Explicit arguments (highest priority)
 // 2. Context file (fallback)

--- a/internal/dvbcontext/resolve_test.go
+++ b/internal/dvbcontext/resolve_test.go
@@ -117,3 +117,38 @@ func TestResolve(t *testing.T) {
 		})
 	}
 }
+
+func TestNoDevnetError(t *testing.T) {
+	t.Run("error message without suggestion", func(t *testing.T) {
+		err := NewNoDevnetError("")
+		msg := err.Error()
+		expected := "no devnet specified and no context set. Run 'dvb use <devnet>' to set context"
+		if msg != expected {
+			t.Errorf("NoDevnetError.Error() = %q, want %q", msg, expected)
+		}
+	})
+
+	t.Run("error message with suggestion", func(t *testing.T) {
+		suggestion := "Found 1 devnet: my-devnet\n\nRun: dvb use my-devnet"
+		err := NewNoDevnetError(suggestion)
+		msg := err.Error()
+		expected := "no devnet specified and no context set\n\n" + suggestion
+		if msg != expected {
+			t.Errorf("NoDevnetError.Error() = %q, want %q", msg, expected)
+		}
+	})
+
+	t.Run("errors.Is compatibility with ErrNoDevnet", func(t *testing.T) {
+		err := NewNoDevnetError("some suggestion")
+		if !errors.Is(err, ErrNoDevnet) {
+			t.Errorf("errors.Is(NoDevnetError, ErrNoDevnet) = false, want true")
+		}
+	})
+
+	t.Run("errors.Is with nil target returns false", func(t *testing.T) {
+		err := NewNoDevnetError("some suggestion")
+		if errors.Is(err, nil) {
+			t.Errorf("errors.Is(NoDevnetError, nil) = true, want false")
+		}
+	})
+}

--- a/internal/dvbcontext/suggest.go
+++ b/internal/dvbcontext/suggest.go
@@ -1,0 +1,52 @@
+package dvbcontext
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/altuslabsxyz/devnet-builder/internal/client"
+)
+
+// SuggestUsage returns formatted suggestion text based on available devnets.
+// Returns empty string if client is nil or if there's an error fetching devnets.
+func SuggestUsage(c *client.Client) string {
+	if c == nil {
+		return ""
+	}
+
+	devnets, err := c.ListDevnets(context.Background(), "")
+	if err != nil {
+		return ""
+	}
+
+	if len(devnets) == 0 {
+		return "No devnets found. Create one first:\n  dvb init my-devnet"
+	}
+
+	if len(devnets) == 1 {
+		d := devnets[0]
+		name := d.Metadata.Name
+		if d.Metadata.Namespace != "" && d.Metadata.Namespace != "default" {
+			name = d.Metadata.Namespace + "/" + d.Metadata.Name
+		}
+		return fmt.Sprintf("Found 1 devnet: %s\n\nRun: dvb use %s", name, name)
+	}
+
+	// Multiple devnets
+	var sb strings.Builder
+	sb.WriteString("Available devnets:\n")
+	for _, d := range devnets {
+		name := d.Metadata.Name
+		if d.Metadata.Namespace != "" && d.Metadata.Namespace != "default" {
+			name = d.Metadata.Namespace + "/" + d.Metadata.Name
+		}
+		phase := ""
+		if d.Status != nil && d.Status.Phase != "" {
+			phase = fmt.Sprintf(" (%s)", strings.ToLower(d.Status.Phase))
+		}
+		sb.WriteString(fmt.Sprintf("  %s%s\n", name, phase))
+	}
+	sb.WriteString("\nRun: dvb use <devnet>")
+	return sb.String()
+}

--- a/internal/dvbcontext/suggest_test.go
+++ b/internal/dvbcontext/suggest_test.go
@@ -1,0 +1,15 @@
+package dvbcontext
+
+import (
+	"testing"
+)
+
+func TestSuggestUsage_NilClient(t *testing.T) {
+	result := SuggestUsage(nil)
+	if result != "" {
+		t.Errorf("SuggestUsage(nil) = %q, want empty string", result)
+	}
+}
+
+// Note: Testing with an actual client requires a running daemon,
+// so comprehensive client integration tests should be in a separate _integration_test.go file.


### PR DESCRIPTION
## Summary
- Add `dvb status` command showing current context, running devnets, and suggested actions
- Add smart error messages that show available devnets when context is missing
- Add context header visibility (`Using: <devnet>`) in command output

## Changes
- `cmd/dvb/status.go` - new status command
- `internal/dvbcontext/suggest.go` - suggestion logic for smart errors
- Updated `main.go`, `node.go`, `logs.go` to use new helpers
- Added `NoDevnetError` type for enriched error messages

## Test plan
- [x] `go build ./cmd/dvb/...` passes
- [x] `go test ./internal/dvbcontext/...` passes
- [ ] Manual test: `dvb status` with/without context
- [ ] Manual test: `dvb start` without context shows suggestions