### PR TITLE
fix: distribute forked genesis to node config directories

### DIFF
--- a/internal/daemon/provisioner/orchestrator_test.go
+++ b/internal/daemon/provisioner/orchestrator_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -78,6 +79,16 @@ func (m *mockNodeInitializer) Initialize(ctx context.Context, nodeDir, moniker, 
 		moniker string
 		chainID string
 	}{nodeDir, moniker, chainID})
+
+	// Create config directory like the real initializer does
+	// This is needed because the orchestrator writes genesis to config/genesis.json
+	if m.initializeErr == nil {
+		configDir := filepath.Join(nodeDir, "config")
+		if err := os.MkdirAll(configDir, 0755); err != nil {
+			return err
+		}
+	}
+
 	return m.initializeErr
 }
 


### PR DESCRIPTION
## Summary
- Fix validator startup failure by writing forked genesis to node config directories
- The orchestrator now distributes the forked genesis after node initialization
- Added integration test to verify genesis distribution

## Problem
Nodes failed to start because they had a placeholder genesis (7KB) instead of the actual forked genesis (3.1GB).

## Solution
After node initialization, write `forkResult.Genesis` to each node's `config/genesis.json`.