### PR TITLE
fix: harden dvb CLI error handling

### DIFF
--- a/cmd/dvb/daemon_logs.go
+++ b/cmd/dvb/daemon_logs.go
@@ -125,12 +125,19 @@ func followDaemonLogs(ctx context.Context, logPath string, level string) error {
 	}
 
 	// Seek to end and read last few lines for context
-	stat, _ := file.Stat()
+	stat, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return fmt.Errorf("failed to stat log file: %w", err)
+	}
 	var startPos int64
 	if stat.Size() > 8192 {
 		startPos = stat.Size() - 8192
 	}
-	_, _ = file.Seek(startPos, 0)
+	if _, err := file.Seek(startPos, 0); err != nil {
+		file.Close()
+		return fmt.Errorf("failed to seek in log file: %w", err)
+	}
 
 	// Skip partial first line if we seeked
 	if startPos > 0 {

--- a/cmd/dvb/get.go
+++ b/cmd/dvb/get.go
@@ -154,17 +154,43 @@ func printNodes(nodes []*v1.Node) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "INDEX\tROLE\tPHASE\tHEALTH\tHEIGHT\tPEERS")
 	for _, n := range nodes {
-		health := "Unknown"
-		if n.Status.Health != nil {
-			health = n.Status.Health.Status
+		if n == nil {
+			continue
 		}
+
+		// Safely extract fields with nil checks
+		var index int32
+		if n.Metadata != nil {
+			index = n.Metadata.Index
+		}
+
+		var role string
+		if n.Spec != nil {
+			role = n.Spec.Role
+		}
+
+		var phase, health string
+		var blockHeight int64
+		var peerCount int32
+		if n.Status != nil {
+			phase = n.Status.Phase
+			blockHeight = n.Status.BlockHeight
+			peerCount = n.Status.PeerCount
+			if n.Status.Health != nil {
+				health = n.Status.Health.Status
+			}
+		}
+		if health == "" {
+			health = "Unknown"
+		}
+
 		fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%d\t%d\n",
-			n.Metadata.Index,
-			n.Spec.Role,
-			colorPhase(n.Status.Phase),
+			index,
+			role,
+			colorPhase(phase),
 			health,
-			n.Status.BlockHeight,
-			n.Status.PeerCount)
+			blockHeight,
+			peerCount)
 	}
 	w.Flush()
 }

--- a/internal/daemon/controller/provision_logs.go
+++ b/internal/daemon/controller/provision_logs.go
@@ -121,7 +121,13 @@ func (c *DevnetController) broadcastLog(namespace, name string, entry *Provision
 		case <-sub.done:
 			// Subscriber unsubscribed while we were trying to send
 		default:
-			// Channel buffer full, skip this subscriber
+			// Channel buffer full, log the dropped message
+			if c.logger != nil {
+				c.logger.Warn("provision log dropped due to slow consumer",
+					"namespace", namespace,
+					"devnet", name,
+					"message", entry.Message)
+			}
 		}
 	}
 }

--- a/internal/daemon/store/bolt_devnet.go
+++ b/internal/daemon/store/bolt_devnet.go
@@ -13,6 +13,10 @@ import (
 
 // CreateDevnet creates a new devnet.
 func (s *BoltStore) CreateDevnet(ctx context.Context, devnet *Devnet) error {
+	if devnet == nil {
+		return fmt.Errorf("devnet cannot be nil")
+	}
+
 	return s.db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(bucketDevnets)
 


### PR DESCRIPTION
## Summary
- Add path traversal and symlink escape protection in log commands
- Fix nil pointer panics in node display and store operations  
- Fix goroutine leak in provision TUI with cancellable context
- Fix log tail+follow behavior to show last N lines before following
- Add logging for dropped provision log messages

## Changes
- `cmd/dvb/logs.go`: Path traversal validation, symlink protection
- `cmd/dvb/daemon_logs.go`: Proper error handling for Stat/Seek
- `cmd/dvb/get.go`: Nil checks for nested node fields
- `cmd/dvb/provision.go`: Safe type assertion, cancellable context, errors.Is()
- `internal/daemon/runtime/logs.go`: Composite reader for tail+follow
- `internal/daemon/store/bolt_devnet.go`: Nil devnet check
- `internal/daemon/controller/provision_logs.go`: Log dropped messages

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -short` passes