### PR TITLE
feat: add spinner UI to dvb start/provision

### DIFF
--- a/internal/infrastructure/snapshot/download.go
+++ b/internal/infrastructure/snapshot/download.go
@@ -165,8 +165,7 @@ func downloadFile(ctx context.Context, url, destPath string, logger *output.Logg
 
 	_, err = io.Copy(out, progressReader)
 
-	// Complete progress bar
-	logger.ProgressComplete()
+	// Note: Terminal progress bar removed - progress reported via ProgressReporter
 
 	if err != nil {
 		os.Remove(tmpPath)
@@ -233,10 +232,8 @@ func (pr *progressReader) Read(p []byte) (int, error) {
 
 		pr.lastReport = now
 
-		// Show progress bar (visible by default)
-		pr.logger.Progress(*pr.downloaded, pr.total, pr.currentSpeed)
-
 		// Report step progress if progress reporter is provided
+		// Note: Terminal progress bar removed - CLI displays progress via daemon API
 		if pr.progress != nil {
 			pr.progress.ReportStep(ports.StepProgress{
 				Name:    "Downloading snapshot",

--- a/internal/output/status_spinner.go
+++ b/internal/output/status_spinner.go
@@ -1,0 +1,97 @@
+// internal/output/status_spinner.go
+package output
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+)
+
+var statusSpinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// StatusSpinner displays an animated spinner with a status message.
+// Thread-safe for concurrent updates.
+type StatusSpinner struct {
+	out      io.Writer
+	frameIdx int
+	message  string
+	stop     chan struct{}
+	done     chan struct{}
+	mu       sync.Mutex
+	running  bool
+}
+
+// NewStatusSpinner creates a new StatusSpinner writing to stderr.
+func NewStatusSpinner() *StatusSpinner {
+	return &StatusSpinner{out: os.Stderr}
+}
+
+// Start begins the spinner animation with the given message.
+func (s *StatusSpinner) Start(message string) {
+	s.mu.Lock()
+	if s.running {
+		s.mu.Unlock()
+		return
+	}
+	s.running = true
+	s.message = message
+	s.stop = make(chan struct{})
+	s.done = make(chan struct{})
+	s.mu.Unlock()
+
+	go func() {
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+		defer close(s.done)
+
+		for {
+			select {
+			case <-s.stop:
+				return
+			case <-ticker.C:
+				s.render()
+			}
+		}
+	}()
+}
+
+// Update changes the spinner message.
+func (s *StatusSpinner) Update(message string) {
+	s.mu.Lock()
+	s.message = message
+	s.mu.Unlock()
+	s.render()
+}
+
+// Stop stops the spinner and clears the line.
+func (s *StatusSpinner) Stop() {
+	s.mu.Lock()
+	if !s.running {
+		s.mu.Unlock()
+		return
+	}
+	s.running = false
+	close(s.stop)
+	s.mu.Unlock()
+
+	<-s.done
+	fmt.Fprintf(s.out, "\r%80s\r", "") // Clear line
+}
+
+// StopWithNewline stops the spinner and moves to a new line.
+func (s *StatusSpinner) StopWithNewline() {
+	s.Stop()
+	fmt.Fprintf(s.out, "\n")
+}
+
+func (s *StatusSpinner) render() {
+	s.mu.Lock()
+	msg := s.message
+	idx := s.frameIdx
+	s.frameIdx = (s.frameIdx + 1) % len(statusSpinnerFrames)
+	s.mu.Unlock()
+
+	fmt.Fprintf(s.out, "\r%s %s          ", statusSpinnerFrames[idx], msg)
+}


### PR DESCRIPTION
## Summary
- Add reusable StatusSpinner component for animated CLI feedback
- Apply spinner to `dvb start` for inline status updates
- Apply spinner to `dvb provision --verbose` for long-running operations
- Remove duplicate progress bar from devnetd (CLI shows progress via daemon API)

## Changes
| File | Change |
|------|--------|
| `internal/output/status_spinner.go` | New reusable spinner component |
| `cmd/dvb/main.go` | Spinner for dvb start polling |
| `cmd/dvb/provision.go` | Spinner for verbose mode non-byte steps |
| `internal/infrastructure/snapshot/download.go` | Remove terminal progress bar |

## Test plan
- [x] `go build ./cmd/dvb && go build ./cmd/devnetd`
- [x] `go test ./cmd/dvb/...` - all tests pass
- [ ] Manual: `dvb start` shows spinning animation
- [ ] Manual: `dvb provision --verbose` shows spinner during extraction