### PR TITLE
feat: erase devnet dir on start/provision/delete

### DIFF
--- a/internal/daemon/provisioner/devnet.go
+++ b/internal/daemon/provisioner/devnet.go
@@ -138,10 +138,11 @@ func (p *DevnetProvisioner) SetStepProgressReporterFactory(factory StepProgressR
 	p.stepProgressReporterFactory = factory
 }
 
-// eraseDevnetDir removes the entire devnet data directory to ensure a clean state.
-// Called at the start of Provision to guarantee fresh provisioning.
+// EraseDevnetDir removes the entire devnet data directory to ensure a clean state.
+// Called at the start of Provision to guarantee fresh provisioning, and also
+// during delete to clean up filesystem artifacts.
 // Handles: directory doesn't exist (no error), permission errors (returns error).
-func (p *DevnetProvisioner) eraseDevnetDir(devnetName string) error {
+func (p *DevnetProvisioner) EraseDevnetDir(devnetName string) error {
 	devnetDataDir := filepath.Join(p.dataDir, devnetName)
 
 	p.logger.Info("erasing devnet directory",
@@ -177,7 +178,7 @@ func (p *DevnetProvisioner) Provision(ctx context.Context, devnet *types.Devnet)
 		"hasSubnetAllocator", p.subnetAllocator != nil)
 
 	// Erase existing devnet directory to ensure clean state
-	if err := p.eraseDevnetDir(devnet.Metadata.Name); err != nil {
+	if err := p.EraseDevnetDir(devnet.Metadata.Name); err != nil {
 		return fmt.Errorf("failed to erase devnet directory: %w", err)
 	}
 

--- a/internal/daemon/server/devnet_service.go
+++ b/internal/daemon/server/devnet_service.go
@@ -17,6 +17,11 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// DirEraser removes devnet data directories from the filesystem.
+type DirEraser interface {
+	EraseDevnetDir(devnetName string) error
+}
+
 // DevnetService implements the gRPC DevnetServiceServer.
 type DevnetService struct {
 	v1.UnimplementedDevnetServiceServer
@@ -25,25 +30,28 @@ type DevnetService struct {
 	logger          *slog.Logger
 	ante            *ante.AnteHandler
 	subnetAllocator *subnet.Allocator
+	dirEraser       DirEraser
 }
 
 // NewDevnetService creates a new DevnetService.
-func NewDevnetService(s store.Store, m *controller.Manager) *DevnetService {
+func NewDevnetService(s store.Store, m *controller.Manager, dirEraser DirEraser) *DevnetService {
 	return &DevnetService{
-		store:   s,
-		manager: m,
-		logger:  slog.Default(),
+		store:     s,
+		manager:   m,
+		logger:    slog.Default(),
+		dirEraser: dirEraser,
 	}
 }
 
 // NewDevnetServiceWithAnte creates a new DevnetService with ante handler and subnet allocator.
-func NewDevnetServiceWithAnte(s store.Store, m *controller.Manager, anteHandler *ante.AnteHandler, subnetAlloc *subnet.Allocator) *DevnetService {
+func NewDevnetServiceWithAnte(s store.Store, m *controller.Manager, anteHandler *ante.AnteHandler, subnetAlloc *subnet.Allocator, dirEraser DirEraser) *DevnetService {
 	return &DevnetService{
 		store:           s,
 		manager:         m,
 		logger:          slog.Default(),
 		ante:            anteHandler,
 		subnetAllocator: subnetAlloc,
+		dirEraser:       dirEraser,
 	}
 }
 
@@ -177,6 +185,14 @@ func (s *DevnetService) DeleteDevnet(ctx context.Context, req *v1.DeleteDevnetRe
 			// Continue with devnet deletion even if subnet release fails
 		} else {
 			s.logger.Debug("released subnet for devnet", "devnet", req.Name)
+		}
+	}
+
+	// Erase devnet data directory from filesystem
+	if s.dirEraser != nil {
+		if err := s.dirEraser.EraseDevnetDir(req.Name); err != nil {
+			s.logger.Warn("failed to erase devnet directory", "devnet", req.Name, "error", err)
+			// Continue with devnet deletion even if directory cleanup fails
 		}
 	}
 

--- a/internal/daemon/server/devnet_service_test.go
+++ b/internal/daemon/server/devnet_service_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestDevnetService_Create(t *testing.T) {
 	s := store.NewMemoryStore()
-	svc := NewDevnetService(s, nil)
+	svc := NewDevnetService(s, nil, nil)
 
 	req := &v1.CreateDevnetRequest{
 		Name: "test-devnet",
@@ -58,7 +58,7 @@ func TestDevnetService_Create(t *testing.T) {
 
 func TestDevnetService_CreateAlreadyExists(t *testing.T) {
 	s := store.NewMemoryStore()
-	svc := NewDevnetService(s, nil)
+	svc := NewDevnetService(s, nil, nil)
 
 	req := &v1.CreateDevnetRequest{
 		Name: "duplicate",
@@ -91,7 +91,7 @@ func TestDevnetService_CreateAlreadyExists(t *testing.T) {
 
 func TestDevnetService_CreateMissingName(t *testing.T) {
 	s := store.NewMemoryStore()
-	svc := NewDevnetService(s, nil)
+	svc := NewDevnetService(s, nil, nil)
 
 	req := &v1.CreateDevnetRequest{
 		Name: "", // Missing name
@@ -116,7 +116,7 @@ func TestDevnetService_CreateMissingName(t *testing.T) {
 
 func TestDevnetService_Get(t *testing.T) {
 	s := store.NewMemoryStore()
-	svc := NewDevnetService(s, nil)
+	svc := NewDevnetService(s, nil, nil)
 
 	// Create a devnet
 	createReq := &v1.CreateDevnetRequest{
@@ -145,7 +145,7 @@ func TestDevnetService_Get(t *testing.T) {
 
 func TestDevnetService_GetNotFound(t *testing.T) {
 	s := store.NewMemoryStore()
-	svc := NewDevnetService(s, nil)
+	svc := NewDevnetService(s, nil, nil)
 
 	req := &v1.GetDevnetRequest{Name: "non-existent"}
 	_, err := svc.GetDevnet(context.Background(), req)
@@ -164,7 +164,7 @@ func TestDevnetService_GetNotFound(t *testing.T) {
 
 func TestDevnetService_List(t *testing.T) {
 	s := store.NewMemoryStore()
-	svc := NewDevnetService(s, nil)
+	svc := NewDevnetService(s, nil, nil)
 
 	// Create multiple devnets
 	for _, name := range []string{"devnet-1", "devnet-2", "devnet-3"} {
@@ -194,7 +194,7 @@ func TestDevnetService_List(t *testing.T) {
 
 func TestDevnetService_Delete(t *testing.T) {
 	s := store.NewMemoryStore()
-	svc := NewDevnetService(s, nil)
+	svc := NewDevnetService(s, nil, nil)
 
 	// Create a devnet
 	createReq := &v1.CreateDevnetRequest{
@@ -229,7 +229,7 @@ func TestDevnetService_Delete(t *testing.T) {
 
 func TestDevnetService_DeleteNotFound(t *testing.T) {
 	s := store.NewMemoryStore()
-	svc := NewDevnetService(s, nil)
+	svc := NewDevnetService(s, nil, nil)
 
 	req := &v1.DeleteDevnetRequest{Name: "non-existent"}
 	_, err := svc.DeleteDevnet(context.Background(), req)
@@ -248,7 +248,7 @@ func TestDevnetService_DeleteNotFound(t *testing.T) {
 
 func TestDevnetService_StartDevnet(t *testing.T) {
 	s := store.NewMemoryStore()
-	svc := NewDevnetService(s, nil)
+	svc := NewDevnetService(s, nil, nil)
 
 	// Create and simulate it being stopped
 	createReq := &v1.CreateDevnetRequest{
@@ -282,7 +282,7 @@ func TestDevnetService_StartDevnet(t *testing.T) {
 
 func TestDevnetService_StopDevnet(t *testing.T) {
 	s := store.NewMemoryStore()
-	svc := NewDevnetService(s, nil)
+	svc := NewDevnetService(s, nil, nil)
 
 	// Create a devnet
 	createReq := &v1.CreateDevnetRequest{
@@ -316,7 +316,7 @@ func TestDevnetService_StopDevnet(t *testing.T) {
 func TestDevnetService_DeleteCascade(t *testing.T) {
 	ctx := context.Background()
 	s := store.NewMemoryStore()
-	svc := NewDevnetService(s, nil)
+	svc := NewDevnetService(s, nil, nil)
 
 	// Create a devnet
 	createReq := &v1.CreateDevnetRequest{
@@ -401,7 +401,7 @@ func TestDevnetService_DeleteCascade(t *testing.T) {
 
 func TestDevnetServiceNamespaceIsolation(t *testing.T) {
 	s := store.NewMemoryStore()
-	svc := NewDevnetService(s, nil)
+	svc := NewDevnetService(s, nil, nil)
 	ctx := context.Background()
 
 	// Create devnet in "prod" namespace
@@ -496,7 +496,7 @@ func TestDevnetService_CreateWithAnteHandler(t *testing.T) {
 	s := store.NewMemoryStore()
 	mockNetSvc := &mockNetworkServiceForDevnetTest{}
 	anteHandler := ante.New(s, mockNetSvc)
-	svc := NewDevnetServiceWithAnte(s, nil, anteHandler, nil)
+	svc := NewDevnetServiceWithAnte(s, nil, anteHandler, nil, nil)
 
 	// Test invalid mode rejected by ante handler
 	req := &v1.CreateDevnetRequest{
@@ -565,7 +565,7 @@ func (m *mockProvisionLogsStream) RecvMsg(interface{}) error    { return nil }
 
 func TestDevnetService_StreamProvisionLogs_MissingName(t *testing.T) {
 	s := store.NewMemoryStore()
-	svc := NewDevnetService(s, nil)
+	svc := NewDevnetService(s, nil, nil)
 
 	req := &v1.StreamProvisionLogsRequest{
 		Name: "", // Missing name
@@ -591,7 +591,7 @@ func TestDevnetService_StreamProvisionLogs_MissingName(t *testing.T) {
 
 func TestDevnetService_StreamProvisionLogs_NoManager(t *testing.T) {
 	s := store.NewMemoryStore()
-	svc := NewDevnetService(s, nil) // No manager
+	svc := NewDevnetService(s, nil, nil) // No manager
 
 	req := &v1.StreamProvisionLogsRequest{
 		Name: "test-devnet",
@@ -621,7 +621,7 @@ func TestDevnetService_StreamProvisionLogs_ReceivesLogs(t *testing.T) {
 	devnetCtrl := controller.NewDevnetController(s, nil)
 	mgr.Register("devnets", devnetCtrl)
 
-	svc := NewDevnetService(s, mgr)
+	svc := NewDevnetService(s, mgr, nil)
 
 	req := &v1.StreamProvisionLogsRequest{
 		Name: "test-devnet",
@@ -669,7 +669,7 @@ func TestDevnetService_StreamProvisionLogs_ChannelClosed(t *testing.T) {
 	devnetCtrl := controller.NewDevnetController(s, nil)
 	mgr.Register("devnets", devnetCtrl)
 
-	svc := NewDevnetService(s, mgr)
+	svc := NewDevnetService(s, mgr, nil)
 
 	req := &v1.StreamProvisionLogsRequest{
 		Name: "test-devnet",
@@ -726,7 +726,7 @@ func TestDevnetService_StreamProvisionLogs_ContextCancelled(t *testing.T) {
 	devnetCtrl := controller.NewDevnetController(s, nil)
 	mgr.Register("devnets", devnetCtrl)
 
-	svc := NewDevnetService(s, mgr)
+	svc := NewDevnetService(s, mgr, nil)
 
 	req := &v1.StreamProvisionLogsRequest{
 		Name:      "test-devnet",

--- a/internal/daemon/server/server.go
+++ b/internal/daemon/server/server.go
@@ -315,7 +315,7 @@ func New(config *Config) (*Server, error) {
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 
 	// Register services
-	devnetSvc := NewDevnetServiceWithAnte(st, mgr, anteHandler, subnetAlloc)
+	devnetSvc := NewDevnetServiceWithAnte(st, mgr, anteHandler, subnetAlloc, devnetProv)
 	devnetSvc.SetLogger(logger)
 	v1.RegisterDevnetServiceServer(grpcServer, devnetSvc)
 


### PR DESCRIPTION
## Summary
- Erase entire devnet data directory on start, provision, and delete operations
- Export `EraseDevnetDir` from provisioner, reuse via `DirEraser` interface in server
- Non-fatal cleanup on delete (warn + continue), matching existing cascade pattern

## Test plan
- [x] `go test ./internal/daemon/provisioner/...`
- [x] `go test ./internal/daemon/server/...`
- [x] `go build ./...`