### PR TITLE
fix(dvb): remove dead code and fix -f flag showing no output

### DIFF
--- a/cmd/dvb/logs.go
+++ b/cmd/dvb/logs.go
@@ -503,20 +503,6 @@ func tailLines(file *os.File, n int) ([]string, error) {
 	return lines, nil
 }
 
-// looksLikeNodeIdentifier returns true if the string looks like a node identifier.
-// Node identifiers are: pure numeric (0, 1, 2) or "validator-N" / "node-N" patterns.
-func looksLikeNodeIdentifier(s string) bool {
-	// Pure numeric
-	if _, err := parseNodeIndex(s); err == nil {
-		return true
-	}
-	// Common node name patterns
-	if strings.HasPrefix(s, "validator-") || strings.HasPrefix(s, "node-") || strings.HasPrefix(s, "full-") {
-		return true
-	}
-	return false
-}
-
 // nodeLogStreamer streams logs from the daemon for a specific node.
 type nodeLogStreamer interface {
 	StreamNodeLogs(ctx context.Context, devnetName string, index int, follow bool, since string, tail int, callback func(*client.LogEntry) error) error

--- a/cmd/dvb/logs_test.go
+++ b/cmd/dvb/logs_test.go
@@ -93,29 +93,6 @@ func TestIsPathWithinBase(t *testing.T) {
 	}
 }
 
-func TestLooksLikeNodeIdentifier(t *testing.T) {
-	tests := []struct {
-		input string
-		want  bool
-	}{
-		{"0", true},
-		{"5", true},
-		{"validator-0", true},
-		{"node-1", true},
-		{"full-3", true},
-		{"my-devnet", false},
-		{"cosmos", false},
-		{"mainnet", false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			if got := looksLikeNodeIdentifier(tt.input); got != tt.want {
-				t.Errorf("looksLikeNodeIdentifier(%q) = %v, want %v", tt.input, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestGetNodeColor(t *testing.T) {
 	// Same input should always return same color (deterministic)
 	c1 := getNodeColor("validator-0")

--- a/internal/daemon/runtime/logs.go
+++ b/internal/daemon/runtime/logs.go
@@ -12,7 +12,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/nxadm/tail"
 )
@@ -101,24 +100,10 @@ func (lm *LogManager) followFile(ctx context.Context, logPath string, lines int)
 	// The tail package doesn't support "last N lines" directly - Location is for byte offset.
 	var initialContent io.ReadCloser
 	if lines > 0 {
-		// Check if file has been recently modified (within last 2 seconds).
-		// If not, the content is likely stale (e.g., from before a node restart),
-		// so we skip showing initial content and just follow for new logs.
-		const freshnessThreshold = 2 * time.Second
-		showInitialContent := true
-		if info, err := os.Stat(logPath); err == nil {
-			if time.Since(info.ModTime()) > freshnessThreshold {
-				showInitialContent = false
-			}
-		}
-
-		if showInitialContent {
-			// Read the last N lines first
-			var err error
-			initialContent, err = lm.tailFile(logPath, lines)
-			if err != nil {
-				return nil, fmt.Errorf("failed to read initial lines: %w", err)
-			}
+		var err error
+		initialContent, err = lm.tailFile(logPath, lines)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read initial lines: %w", err)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Remove dead `looksLikeNodeIdentifier` function that referenced removed `parseNodeIndex`
- Remove 2-second freshness threshold in `runtime/logs.go` that caused `dvb node logs -f` to show no initial output when the log file wasn't recently modified
- Remove associated dead test `TestLooksLikeNodeIdentifier`

## Test plan
- [x] `go build ./cmd/dvb/` compiles clean
- [x] `go vet ./cmd/dvb/` passes
- [x] `go test ./cmd/dvb/ -v` all tests pass
- [x] `go build ./internal/daemon/runtime/` compiles clean