### PR TITLE
fix: remove chain-id prompt from provision

### DIFF
--- a/cmd/dvb/provision.go
+++ b/cmd/dvb/provision.go
@@ -187,7 +187,6 @@ func runInteractiveMode(ctx context.Context, opts *provisionOptions) error {
 		Mode:        wizardOpts.Mode,
 		SdkVersion:  wizardOpts.BinaryVersion,
 		ForkNetwork: wizardOpts.ForkNetwork,
-		ChainId:     wizardOpts.ChainID,
 	}
 
 	namespace := "default"
@@ -639,7 +638,6 @@ type YAMLProvisionSpecOutput struct {
 	Validators     int    `json:"validators" yaml:"validators"`
 	FullNodes      int    `json:"fullNodes,omitempty" yaml:"fullNodes,omitempty"`
 	Mode           string `json:"mode" yaml:"mode"`
-	ChainID        string `json:"chainId,omitempty" yaml:"chainId,omitempty"`
 	ForkNetwork    string `json:"forkNetwork,omitempty" yaml:"forkNetwork,omitempty"`
 }
 

--- a/cmd/dvb/provision_test.go
+++ b/cmd/dvb/provision_test.go
@@ -26,7 +26,6 @@ func TestFormatProvisionYAML(t *testing.T) {
 		Mode:        "docker",
 		SdkVersion:  "v1.0.0",
 		ForkNetwork: "mainnet",
-		ChainId:     "mainnet-1",
 	}
 
 	var buf bytes.Buffer
@@ -74,7 +73,6 @@ func TestFormatProvisionYAML_OmitsEmptyFields(t *testing.T) {
 		"networkType:",
 		"networkVersion:",
 		"fullNodes:",
-		"chainId:",
 		"namespace:",
 		"forkNetwork:",
 	}

--- a/cmd/dvb/wizard.go
+++ b/cmd/dvb/wizard.go
@@ -22,7 +22,6 @@ type WizardOptions struct {
 	FullNodes     int
 	ForkNetwork   string // Network to fork from (e.g., "mainnet", "testnet", ""). Empty means fresh genesis.
 	Mode          string // Execution mode: "local" or "docker"
-	ChainID       string // Chain ID for the devnet (e.g., "mainnet-1", "mydevnet-1")
 	BinaryVersion string // Binary version to use (required when forking from snapshot)
 }
 
@@ -122,32 +121,6 @@ func RunProvisionWizard(daemonClient *client.Client) (*WizardOptions, error) {
 		}
 		opts.BinaryVersion = binaryVersion
 
-		// Chain ID for forked network - must match source network's chain-id
-		defaultChainID := forkNetwork + "-1"
-		fmt.Printf("  Note: When forking, chain-id should match the source network's chain-id.\n")
-		chainIDPrompt := promptui.Prompt{
-			Label:    "Chain ID",
-			Default:  defaultChainID,
-			Validate: validateNonEmpty,
-		}
-		chainID, err := chainIDPrompt.Run()
-		if err != nil {
-			return nil, handlePromptError(err, "chain ID")
-		}
-		opts.ChainID = strings.TrimSpace(chainID)
-	} else {
-		// Fresh genesis - use devnet name as default chain-id
-		defaultChainID := opts.Name + "-1"
-		chainIDPrompt := promptui.Prompt{
-			Label:    "Chain ID",
-			Default:  defaultChainID,
-			Validate: validateNonEmpty,
-		}
-		chainID, err := chainIDPrompt.Run()
-		if err != nil {
-			return nil, handlePromptError(err, "chain ID")
-		}
-		opts.ChainID = strings.TrimSpace(chainID)
 	}
 
 	// 3. Number of Validators
@@ -183,7 +156,6 @@ func RunProvisionWizard(daemonClient *client.Client) (*WizardOptions, error) {
 	fmt.Printf("  Name:       %s\n", opts.Name)
 	fmt.Printf("  Network:    %s\n", opts.Network)
 	fmt.Printf("  Mode:       %s\n", opts.Mode)
-	fmt.Printf("  Chain ID:   %s\n", opts.ChainID)
 	fmt.Printf("  Validators: %d\n", opts.Validators)
 	fmt.Printf("  Full Nodes: %d\n", opts.FullNodes)
 	if opts.ForkNetwork != "" {


### PR DESCRIPTION
## Summary
- Remove chain-id user prompt from the provisioning wizard (both fork and fresh genesis paths)
- Remove ChainID from WizardOptions, DevnetSpec construction, YAML output struct, and tests
- Server-side fallback logic determines chain-id automatically (from devnet name or source genesis)

## Test plan
- [x] `go build ./cmd/dvb/` compiles clean
- [x] `go vet ./cmd/dvb/` passes
- [x] `go test ./cmd/dvb/ -v` all tests pass
- [x] `go test ./internal/daemon/provisioner/ -v` server-side tests pass