### PR TITLE
fix: thread subnet into orchestrator to prevent port collisions

### DIFF
--- a/internal/application/ports/provisioner.go
+++ b/internal/application/ports/provisioner.go
@@ -192,6 +192,11 @@ type ProvisionOptions struct {
 	// Used in daemon mode where NodeController handles starting nodes
 	// via reconciliation instead of the orchestrator starting them directly.
 	SkipStart bool
+
+	// Subnet is the allocated loopback subnet for this devnet (1-254).
+	// When set, nodes bind to 127.0.{Subnet}.{nodeIndex+1} instead of 0.0.0.0.
+	// This enables multiple devnets to coexist on the same host without port conflicts.
+	Subnet uint8
 }
 
 // ProvisionResult contains the result of a full provisioning operation.

--- a/internal/daemon/provisioner/devnet_test.go
+++ b/internal/daemon/provisioner/devnet_test.go
@@ -653,7 +653,7 @@ func TestDevnetToProvisionOptions_BasicConversion(t *testing.T) {
 		},
 	}
 
-	opts, err := devnetToProvisionOptions(devnet, "/data", nil)
+	opts, err := devnetToProvisionOptions(devnet, "/data", nil, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -690,7 +690,7 @@ func TestDevnetToProvisionOptions_LocalBinarySource(t *testing.T) {
 		},
 	}
 
-	opts, err := devnetToProvisionOptions(devnet, "/data", nil)
+	opts, err := devnetToProvisionOptions(devnet, "/data", nil, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -717,7 +717,7 @@ func TestDevnetToProvisionOptions_CacheBinarySource(t *testing.T) {
 		},
 	}
 
-	opts, err := devnetToProvisionOptions(devnet, "/data", nil)
+	opts, err := devnetToProvisionOptions(devnet, "/data", nil, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -741,7 +741,7 @@ func TestDevnetToProvisionOptions_LocalGenesis(t *testing.T) {
 		},
 	}
 
-	opts, err := devnetToProvisionOptions(devnet, "/data", nil)
+	opts, err := devnetToProvisionOptions(devnet, "/data", nil, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -769,7 +769,7 @@ func TestDevnetToProvisionOptions_SnapshotGenesis(t *testing.T) {
 		},
 	}
 
-	opts, err := devnetToProvisionOptions(devnet, "/data", nil)
+	opts, err := devnetToProvisionOptions(devnet, "/data", nil, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -793,7 +793,7 @@ func TestDevnetToProvisionOptions_FreshGenesisDefault(t *testing.T) {
 		},
 	}
 
-	opts, err := devnetToProvisionOptions(devnet, "/data", nil)
+	opts, err := devnetToProvisionOptions(devnet, "/data", nil, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -815,7 +815,7 @@ func TestDevnetToProvisionOptions_RPCGenesisFromSpec(t *testing.T) {
 		},
 	}
 
-	opts, err := devnetToProvisionOptions(devnet, "/data", nil)
+	opts, err := devnetToProvisionOptions(devnet, "/data", nil, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -843,7 +843,7 @@ func TestDevnetToProvisionOptions_RPCGenesisFromDefaults(t *testing.T) {
 		RPCURL: "https://default-rpc.example.com",
 	}
 
-	opts, err := devnetToProvisionOptions(devnet, "/data", defaults)
+	opts, err := devnetToProvisionOptions(devnet, "/data", defaults, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -876,7 +876,7 @@ func TestDevnetToProvisionOptions_SnapshotGenesisFromDefaults(t *testing.T) {
 		RPCURL:      "https://default-rpc.example.com",
 	}
 
-	opts, err := devnetToProvisionOptions(devnet, "/data", defaults)
+	opts, err := devnetToProvisionOptions(devnet, "/data", defaults, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -900,7 +900,7 @@ func TestDevnetToProvisionOptions_ChainIDGeneration(t *testing.T) {
 		},
 	}
 
-	opts, err := devnetToProvisionOptions(devnet, "/data", nil)
+	opts, err := devnetToProvisionOptions(devnet, "/data", nil, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -924,7 +924,7 @@ func TestDevnetToProvisionOptions_SnapshotRequiresVersion(t *testing.T) {
 		},
 	}
 
-	_, err := devnetToProvisionOptions(devnet, "/data", nil)
+	_, err := devnetToProvisionOptions(devnet, "/data", nil, 0)
 	if err == nil {
 		t.Fatal("Expected SnapshotVersionRequiredError, got nil")
 	}
@@ -961,7 +961,7 @@ func TestDevnetToProvisionOptions_SnapshotFromDefaultsRequiresVersion(t *testing
 		SnapshotURL: "https://default-snapshot.example.com/chain.tar.gz",
 	}
 
-	_, err := devnetToProvisionOptions(devnet, "/data", defaults)
+	_, err := devnetToProvisionOptions(devnet, "/data", defaults, 0)
 	if err == nil {
 		t.Fatal("Expected SnapshotVersionRequiredError, got nil")
 	}
@@ -990,7 +990,7 @@ func TestDevnetToProvisionOptions_EmptyTypeWithVersionSet(t *testing.T) {
 		},
 	}
 
-	opts, err := devnetToProvisionOptions(devnet, "/data", nil)
+	opts, err := devnetToProvisionOptions(devnet, "/data", nil, 0)
 	if err != nil {
 		t.Fatalf("Expected success with empty Type but Version set, got error: %v", err)
 	}
@@ -1016,7 +1016,7 @@ func TestDevnetToProvisionOptions_EmptyTypeWithoutVersion(t *testing.T) {
 		},
 	}
 
-	_, err := devnetToProvisionOptions(devnet, "/data", nil)
+	_, err := devnetToProvisionOptions(devnet, "/data", nil, 0)
 	if err == nil {
 		t.Fatal("Expected SnapshotVersionRequiredError for empty Type and Version")
 	}

--- a/internal/daemon/provisioner/orchestrator.go
+++ b/internal/daemon/provisioner/orchestrator.go
@@ -19,6 +19,7 @@ import (
 	"github.com/altuslabsxyz/devnet-builder/internal/daemon/builder"
 	"github.com/altuslabsxyz/devnet-builder/internal/daemon/controller"
 	"github.com/altuslabsxyz/devnet-builder/internal/daemon/runtime"
+	"github.com/altuslabsxyz/devnet-builder/internal/daemon/subnet"
 	"github.com/altuslabsxyz/devnet-builder/internal/daemon/types"
 	"github.com/altuslabsxyz/devnet-builder/internal/infrastructure/nodeconfig"
 	plugintypes "github.com/altuslabsxyz/devnet-builder/internal/plugin/types"
@@ -615,6 +616,12 @@ func (o *ProvisioningOrchestrator) initializeNode(ctx context.Context, opts port
 		return nil, fmt.Errorf("node initialization failed: %w", err)
 	}
 
+	// Compute node address from subnet allocation
+	var nodeAddress string
+	if opts.Subnet > 0 {
+		nodeAddress = subnet.NodeIP(opts.Subnet, index)
+	}
+
 	// Create Node resource
 	node := &types.Node{
 		Metadata: types.ResourceMeta{
@@ -626,6 +633,7 @@ func (o *ProvisioningOrchestrator) initializeNode(ctx context.Context, opts port
 			Role:       role,
 			BinaryPath: binaryPath,
 			HomeDir:    nodeDir,
+			Address:    nodeAddress,
 			Desired:    types.NodePhaseRunning,
 			ChainID:    opts.ChainID,
 			Network:    opts.Network,


### PR DESCRIPTION
## Summary
- Provisioning a new devnet while another is running causes port collisions because the orchestrator creates nodes with empty `Spec.Address`, causing all nodes to bind to `0.0.0.0` on the same default ports (26657, 26656, etc.)
- Threads the allocated subnet through `ProvisionOptions` so `initializeNode()` sets `node.Spec.Address` to the correct loopback IP (e.g., `127.0.42.1`), enabling `configureNodeNetworking()` to bind each devnet's nodes to unique IPs

## Changes
- Added `Subnet uint8` field to `ProvisionOptions`
- Passed `allocatedSubnet` through `provisionWithOrchestrator()` and `devnetToProvisionOptions()`
- Set `node.Spec.Address` via `subnet.NodeIP()` in `initializeNode()` when subnet > 0
- Updated test call sites for the changed function signature

## Test Plan
- [x] `go build ./...` passes
- [x] `go test ./internal/daemon/provisioner/...` passes
- [x] `go test ./...` full suite passes (0 failures)
- [ ] Deploy and provision two devnets simultaneously, verify nodes bind to different loopback IPs