### PR TITLE
feat(dvb): improve CLI developer experience

### DIFF
--- a/cmd/dvb/completion.go
+++ b/cmd/dvb/completion.go
@@ -1,0 +1,57 @@
+// cmd/dvb/completion.go
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func newCompletionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "completion [bash|zsh|fish|powershell]",
+		Short: "Generate shell completion scripts",
+		Long: `Generate shell completion scripts for dvb.
+
+To load completions:
+
+Bash:
+  $ source <(dvb completion bash)
+  # To load for each session:
+  $ echo 'source <(dvb completion bash)' >> ~/.bashrc
+
+Zsh:
+  $ source <(dvb completion zsh)
+  # To load for each session:
+  $ echo 'source <(dvb completion zsh)' >> ~/.zshrc
+
+Fish:
+  $ dvb completion fish | source
+  # To load for each session:
+  $ dvb completion fish > ~/.config/fish/completions/dvb.fish
+
+PowerShell:
+  PS> dvb completion powershell | Out-String | Invoke-Expression
+  # To load for each session, add to your profile:
+  PS> dvb completion powershell >> $PROFILE`,
+		Args:      cobra.ExactArgs(1),
+		ValidArgs: []string{"bash", "zsh", "fish", "powershell"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch args[0] {
+			case "bash":
+				return cmd.Root().GenBashCompletion(os.Stdout)
+			case "zsh":
+				return cmd.Root().GenZshCompletion(os.Stdout)
+			case "fish":
+				return cmd.Root().GenFishCompletion(os.Stdout, true)
+			case "powershell":
+				return cmd.Root().GenPowerShellCompletion(os.Stdout)
+			default:
+				return fmt.Errorf("unsupported shell: %s (supported: bash, zsh, fish, powershell)", args[0])
+			}
+		},
+	}
+
+	return cmd
+}

--- a/cmd/dvb/daemon.go
+++ b/cmd/dvb/daemon.go
@@ -241,7 +241,7 @@ Examples:
 
 			// Local connection
 			if !client.IsDaemonRunning() {
-				return fmt.Errorf("daemon not running - start with: devnetd")
+				return errDaemonNotRunning
 			}
 
 			// Create local client and call WhoAmI

--- a/cmd/dvb/delete.go
+++ b/cmd/dvb/delete.go
@@ -107,7 +107,7 @@ func runDeleteFromFile(cmd *cobra.Command, namespace, filePath string, force, dr
 	}
 
 	// Confirm if not forced
-	if !force {
+	if !force && !ShouldSkipConfirm() {
 		fmt.Printf("This will delete %d devnet(s):\n", len(devnets))
 		for i := range devnets {
 			ns := devnets[i].Metadata.Namespace
@@ -170,7 +170,7 @@ func runDeleteDevnet(cmd *cobra.Command, namespace, explicitName string, force, 
 	}
 
 	// Confirm if not forced
-	if !force {
+	if !force && !ShouldSkipConfirm() {
 		fmt.Printf("Are you sure you want to delete devnet %q (namespace: %s)? [y/N] ", name, ns)
 		var response string
 		if _, err := fmt.Scanln(&response); err != nil || (response != "y" && response != "Y") {

--- a/cmd/dvb/errors.go
+++ b/cmd/dvb/errors.go
@@ -1,0 +1,16 @@
+// cmd/dvb/errors.go
+package main
+
+import "fmt"
+
+// errDaemonNotRunning is the standard error returned when daemon connection is required but unavailable.
+var errDaemonNotRunning = fmt.Errorf("daemon not running - start with: devnetd")
+
+// requireDaemon returns errDaemonNotRunning if the daemon client is not connected.
+// Usage: if err := requireDaemon(); err != nil { return err }
+func requireDaemon() error {
+	if daemonClient == nil {
+		return errDaemonNotRunning
+	}
+	return nil
+}

--- a/cmd/dvb/get.go
+++ b/cmd/dvb/get.go
@@ -44,8 +44,8 @@ Examples:
   dvb get staging/my-devnet`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if daemonClient == nil {
-				return fmt.Errorf("daemon not running - start with: devnetd")
+			if err := requireDaemon(); err != nil {
+				return err
 			}
 
 			var explicitDevnet string

--- a/cmd/dvb/interactive.go
+++ b/cmd/dvb/interactive.go
@@ -1,0 +1,30 @@
+// cmd/dvb/interactive.go
+package main
+
+import (
+	"os"
+
+	"github.com/altuslabsxyz/devnet-builder/internal/tui"
+)
+
+var (
+	// flagYes auto-confirms all confirmation prompts.
+	flagYes bool
+	// flagNonInteractive disables all interactive UI elements (pickers, wizards, TUI).
+	flagNonInteractive bool
+)
+
+// IsNonInteractive returns true if interactive mode should be disabled.
+// Checks the --non-interactive flag, DVB_NON_INTERACTIVE=1 / CI=true env vars, or non-TTY.
+func IsNonInteractive() bool {
+	return flagNonInteractive ||
+		os.Getenv("DVB_NON_INTERACTIVE") == "1" ||
+		os.Getenv("CI") == "true" ||
+		!tui.IsInteractive()
+}
+
+// ShouldSkipConfirm returns true if confirmation prompts should be auto-accepted.
+// Checks --yes flag, --non-interactive flag, env vars, or non-TTY.
+func ShouldSkipConfirm() bool {
+	return flagYes || IsNonInteractive()
+}

--- a/cmd/dvb/plugins.go
+++ b/cmd/dvb/plugins.go
@@ -52,8 +52,8 @@ Examples:
 
 // runPluginsList lists available network plugins from the daemon
 func runPluginsList(ctx context.Context) error {
-	if daemonClient == nil {
-		return fmt.Errorf("daemon not running - start with: devnetd")
+	if err := requireDaemon(); err != nil {
+		return err
 	}
 
 	networks, err := daemonClient.ListNetworks(ctx)

--- a/cmd/dvb/start_test.go
+++ b/cmd/dvb/start_test.go
@@ -14,8 +14,8 @@ import (
 
 // Note: mockDaemonClient is defined in provision_test.go and shared across test files.
 
-func TestNewStartCmd_FlagRegistration(t *testing.T) {
-	cmd := newStartCmd()
+func TestNewNodeStartCmd_FlagRegistration(t *testing.T) {
+	cmd := newNodeStartCmd()
 
 	// Check that all expected flags are registered
 	flags := []struct {
@@ -23,6 +23,7 @@ func TestNewStartCmd_FlagRegistration(t *testing.T) {
 		shorthand string
 	}{
 		{"namespace", "n"},
+		{"all", ""},
 		{"no-wait", ""},
 		{"verbose", "v"},
 		{"force", "f"},
@@ -40,8 +41,8 @@ func TestNewStartCmd_FlagRegistration(t *testing.T) {
 	}
 }
 
-func TestNewStartCmd_DefaultFlags(t *testing.T) {
-	cmd := newStartCmd()
+func TestNewNodeStartCmd_DefaultFlags(t *testing.T) {
+	cmd := newNodeStartCmd()
 
 	tests := []struct {
 		name     string
@@ -49,6 +50,7 @@ func TestNewStartCmd_DefaultFlags(t *testing.T) {
 		want     string
 	}{
 		{"namespace defaults to empty", "namespace", ""},
+		{"all defaults to false", "all", "false"},
 		{"no-wait defaults to false", "no-wait", "false"},
 		{"verbose defaults to false", "verbose", "false"},
 		{"force defaults to false", "force", "false"},

--- a/cmd/dvb/status.go
+++ b/cmd/dvb/status.go
@@ -583,14 +583,14 @@ func printQuickActions(d *v1.Devnet) {
 
 	switch d.Status.Phase {
 	case "Running":
-		fmt.Println("  dvb stop          # Stop the devnet")
-		fmt.Println("  dvb logs -f       # Follow logs")
-		fmt.Println("  dvb status -v      # Show detailed info")
-		fmt.Println("  dvb node list     # List all nodes")
+		fmt.Println("  dvb node stop --all   # Stop all nodes")
+		fmt.Println("  dvb logs -f           # Follow logs")
+		fmt.Println("  dvb status -v         # Show detailed info")
+		fmt.Println("  dvb node list         # List all nodes")
 	case "Stopped":
-		fmt.Println("  dvb start         # Start the devnet")
-		fmt.Println("  dvb status -v      # Show detailed info")
-		fmt.Println("  dvb delete        # Delete the devnet")
+		fmt.Println("  dvb node start --all  # Start all nodes")
+		fmt.Println("  dvb status -v         # Show detailed info")
+		fmt.Println("  dvb delete            # Delete the devnet")
 	case "Pending", "Provisioning":
 		fmt.Println("  dvb status -v      # Show detailed status")
 		fmt.Println("  dvb daemon logs   # Check daemon logs")

--- a/cmd/dvb/tx.go
+++ b/cmd/dvb/tx.go
@@ -43,8 +43,8 @@ func newTxSubmitCmd() *cobra.Command {
 		Short: "Submit a transaction",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if daemonClient == nil {
-				return fmt.Errorf("daemon not running - start with: devnetd")
+			if err := requireDaemon(); err != nil {
+				return err
 			}
 
 			// Get explicit devnet from args or flag
@@ -112,8 +112,8 @@ func newTxListCmd() *cobra.Command {
 		Aliases: []string{"ls"},
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if daemonClient == nil {
-				return fmt.Errorf("daemon not running - start with: devnetd")
+			if err := requireDaemon(); err != nil {
+				return err
 			}
 
 			// Get explicit devnet from args or flag
@@ -179,8 +179,8 @@ func newTxStatusCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 
-			if daemonClient == nil {
-				return fmt.Errorf("daemon not running - start with: devnetd")
+			if err := requireDaemon(); err != nil {
+				return err
 			}
 
 			tx, err := daemonClient.GetTransaction(cmd.Context(), name)
@@ -202,8 +202,8 @@ func newTxCancelCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 
-			if daemonClient == nil {
-				return fmt.Errorf("daemon not running - start with: devnetd")
+			if err := requireDaemon(); err != nil {
+				return err
 			}
 
 			tx, err := daemonClient.CancelTransaction(cmd.Context(), name)
@@ -247,8 +247,8 @@ func newGovVoteCmd() *cobra.Command {
 		Short: "Submit a governance vote",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if daemonClient == nil {
-				return fmt.Errorf("daemon not running - start with: devnetd")
+			if err := requireDaemon(); err != nil {
+				return err
 			}
 
 			// Get explicit devnet from args or flag
@@ -314,8 +314,8 @@ func newGovProposeCmd() *cobra.Command {
 		Short: "Submit a governance proposal",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if daemonClient == nil {
-				return fmt.Errorf("daemon not running - start with: devnetd")
+			if err := requireDaemon(); err != nil {
+				return err
 			}
 
 			// Get explicit devnet from args or flag

--- a/cmd/dvb/upgrade.go
+++ b/cmd/dvb/upgrade.go
@@ -50,8 +50,8 @@ func newUpgradeCreateCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 
-			if daemonClient == nil {
-				return fmt.Errorf("daemon not running - start with: devnetd")
+			if err := requireDaemon(); err != nil {
+				return err
 			}
 
 			// Resolve devnet from context if not provided
@@ -125,8 +125,8 @@ func newUpgradeListCmd() *cobra.Command {
 		Short:   "List upgrades",
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if daemonClient == nil {
-				return fmt.Errorf("daemon not running - start with: devnetd")
+			if err := requireDaemon(); err != nil {
+				return err
 			}
 
 			upgrades, err := daemonClient.ListUpgrades(cmd.Context(), namespace)
@@ -183,8 +183,8 @@ func newUpgradeStatusCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 
-			if daemonClient == nil {
-				return fmt.Errorf("daemon not running - start with: devnetd")
+			if err := requireDaemon(); err != nil {
+				return err
 			}
 
 			upgrade, err := daemonClient.GetUpgrade(cmd.Context(), namespace, name)
@@ -212,8 +212,8 @@ func newUpgradeCancelCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 
-			if daemonClient == nil {
-				return fmt.Errorf("daemon not running - start with: devnetd")
+			if err := requireDaemon(); err != nil {
+				return err
 			}
 
 			upgrade, err := daemonClient.CancelUpgrade(cmd.Context(), namespace, name)
@@ -243,8 +243,8 @@ func newUpgradeRetryCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 
-			if daemonClient == nil {
-				return fmt.Errorf("daemon not running - start with: devnetd")
+			if err := requireDaemon(); err != nil {
+				return err
 			}
 
 			upgrade, err := daemonClient.RetryUpgrade(cmd.Context(), namespace, name)
@@ -277,11 +277,11 @@ func newUpgradeDeleteCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 
-			if daemonClient == nil {
-				return fmt.Errorf("daemon not running - start with: devnetd")
+			if err := requireDaemon(); err != nil {
+				return err
 			}
 
-			if !force {
+			if !force && !ShouldSkipConfirm() {
 				fmt.Printf("Are you sure you want to delete upgrade %q? [y/N] ", name)
 				var response string
 				if _, err := fmt.Scanln(&response); err != nil || (response != "y" && response != "Y") {

--- a/cmd/dvb/use.go
+++ b/cmd/dvb/use.go
@@ -54,8 +54,8 @@ Examples:
 				namespace, devnetName := dvbcontext.ParseRef(ref)
 
 				// Validate devnet exists via daemon
-				if daemonClient == nil {
-					return errors.New("daemon not running, cannot validate devnet")
+				if err := requireDaemon(); err != nil {
+					return err
 				}
 
 				_, err := daemonClient.GetDevnet(cmd.Context(), namespace, devnetName)
@@ -96,13 +96,22 @@ Examples:
 			}
 
 			if len(devnets) == 0 {
-				return errors.New("no devnets found. Create one with 'dvb provision -i'")
+				return errors.New("no devnets found. Create one with 'dvb provision'")
 			}
 
-			// Build list of ref strings for picker
+			// Build list of ref strings
 			items := make([]string, len(devnets))
 			for i, d := range devnets {
 				items[i] = fmt.Sprintf("%s/%s", d.Metadata.Namespace, d.Metadata.Name)
+			}
+
+			// Non-interactive: list available devnets and return error
+			if IsNonInteractive() {
+				fmt.Println("Available devnets:")
+				for _, item := range items {
+					fmt.Printf("  %s\n", item)
+				}
+				return errors.New("no context set. Run 'dvb use <devnet>' to set context")
 			}
 
 			// Show interactive picker


### PR DESCRIPTION
## Summary
- Add global `--yes/-y` and `--non-interactive` flags for CI/script-friendly usage
- Consolidate `dvb start`/`dvb stop` into `dvb node start/stop/restart --all`
- Add `dvb provision --quick/-q` for fast provisioning with smart defaults
- Auto-set context after `dvb provision`
- Add `dvb completion [shell]` for bash/zsh/fish/powershell
- Add `-o json` output on `dvb list` and `dvb node list`
- Centralize daemon-not-running error handling via `requireDaemon()`
- Gate all interactive pickers (node, devnet) on `IsNonInteractive()`

## Test plan
- [x] `go build ./cmd/dvb/` passes
- [x] `go test ./cmd/dvb/...` passes
- [x] `go vet ./cmd/dvb/...` passes
- [ ] Manual: `dvb --non-interactive node restart` returns error with available nodes
- [ ] Manual: `dvb node start --all` starts all nodes
- [ ] Manual: `dvb provision -q` creates devnet with defaults
- [ ] Manual: `dvb delete my-devnet -y` skips confirmation
- [ ] Manual: `dvb completion zsh` outputs completion script