### PR TITLE
refactor: cli failfast validation prerune

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,4 @@ docs/plans/
 *.test
 .serena/
 
-devnet-builder
+/devnet-builder

--- a/cmd/devnet-builder/commands/core/init.go
+++ b/cmd/devnet-builder/commands/core/init.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/altuslabsxyz/devnet-builder/internal/application"
 	"github.com/altuslabsxyz/devnet-builder/internal/application/dto"
+	cmdvalidation "github.com/altuslabsxyz/devnet-builder/internal/cmd/validation"
 	"github.com/altuslabsxyz/devnet-builder/internal/config"
 	"github.com/altuslabsxyz/devnet-builder/internal/infrastructure/network"
 	"github.com/altuslabsxyz/devnet-builder/internal/output"
@@ -70,7 +71,8 @@ Examples:
 
   # After initializing, modify config then run:
   devnet-builder start`,
-		RunE: runInit,
+		PreRunE: preRunInit,
+		RunE:    runInit,
 	}
 
 	cmd.Flags().StringVarP(&initNetwork, "network", "n", "mainnet",
@@ -89,6 +91,28 @@ Examples:
 		"Blockchain network module (stable, ault)")
 
 	return cmd
+}
+
+func preRunInit(cmd *cobra.Command, args []string) error {
+	if cmd.Flags().Changed("network") {
+		if err := cmdvalidation.ValidateNetworkSource(initNetwork); err != nil {
+			return err
+		}
+	}
+
+	if cmd.Flags().Changed("mode") {
+		if err := cmdvalidation.ValidateMode(initMode); err != nil {
+			return err
+		}
+	}
+
+	if cmd.Flags().Changed("validators") {
+		if err := cmdvalidation.ValidateValidatorsRange(initValidators, 1, 4); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func runInit(cmd *cobra.Command, args []string) error {
@@ -160,15 +184,15 @@ func runInit(cmd *cobra.Command, args []string) error {
 		initAccounts = *effectiveCfg.Accounts
 	}
 
-	// Validate inputs
-	if !types.NetworkSource(initNetwork).IsValid() {
-		return outputInitError(fmt.Errorf("invalid network: %s (must be 'mainnet' or 'testnet')", initNetwork), jsonMode)
+	// Validate inputs after config resolution.
+	if err := cmdvalidation.ValidateNetworkSource(initNetwork); err != nil {
+		return outputInitError(err, jsonMode)
 	}
-	if initValidators < 1 || initValidators > 4 {
-		return outputInitError(fmt.Errorf("invalid validators: %d (must be 1-4)", initValidators), jsonMode)
+	if err := cmdvalidation.ValidateValidatorsRange(initValidators, 1, 4); err != nil {
+		return outputInitError(err, jsonMode)
 	}
-	if !types.ExecutionMode(initMode).IsValid() {
-		return outputInitError(fmt.Errorf("invalid mode: %s (must be 'docker' or 'local')", initMode), jsonMode)
+	if err := cmdvalidation.ValidateMode(initMode); err != nil {
+		return outputInitError(err, jsonMode)
 	}
 	// Validate blockchain network module exists
 	if !network.Has(initBlockchainNetwork) {

--- a/cmd/devnet-builder/commands/manage/deploy.go
+++ b/cmd/devnet-builder/commands/manage/deploy.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/altuslabsxyz/devnet-builder/internal/application"
 	"github.com/altuslabsxyz/devnet-builder/internal/application/dto"
+	cmdvalidation "github.com/altuslabsxyz/devnet-builder/internal/cmd/validation"
 	"github.com/altuslabsxyz/devnet-builder/internal/config"
 	"github.com/altuslabsxyz/devnet-builder/internal/di"
 	"github.com/altuslabsxyz/devnet-builder/internal/infrastructure/binary"
@@ -104,7 +105,8 @@ Examples:
   # Deploy with different binary versions for export and start
   # (useful when export requires a specific version for state compatibility)
   devnet-builder deploy --mode local --start-version v1.2.3 --export-version v1.1.0`,
-		RunE: runDeploy,
+		PreRunE: preRunDeploy,
+		RunE:    runDeploy,
 	}
 
 	// Command flags
@@ -145,6 +147,45 @@ Examples:
 		"Fork live network state (export genesis from snapshot)")
 
 	return cmd
+}
+
+func preRunDeploy(cmd *cobra.Command, args []string) error {
+	if cmd.Flags().Changed("network") {
+		if err := cmdvalidation.ValidateNetworkSource(deployNetwork); err != nil {
+			return err
+		}
+	}
+
+	if cmd.Flags().Changed("mode") {
+		if err := cmdvalidation.ValidateMode(deployMode); err != nil {
+			return err
+		}
+	}
+
+	if cmd.Flags().Changed("validators") {
+		mode := resolveDeployModeForValidation(cmd)
+		if err := cmdvalidation.ValidateValidatorsForMode(mode, deployValidators); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func resolveDeployModeForValidation(cmd *cobra.Command) string {
+	mode := deployMode
+
+	cfg := ctxconfig.FromContext(cmd.Context())
+	fileCfg := cfg.FileConfig()
+	if fileCfg != nil && fileCfg.ExecutionMode != nil && !cmd.Flags().Changed("mode") {
+		mode = string(*fileCfg.ExecutionMode)
+	}
+
+	if envMode := os.Getenv("DEVNET_MODE"); envMode != "" && !cmd.Flags().Changed("mode") {
+		mode = envMode
+	}
+
+	return mode
 }
 
 func runDeploy(cmd *cobra.Command, args []string) error {
@@ -289,21 +330,12 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Validate inputs
-	if !types.NetworkSource(deployNetwork).IsValid() {
-		return fmt.Errorf("invalid network: %s (must be 'mainnet' or 'testnet')", deployNetwork)
+	// Validate inputs after config resolution.
+	if err := cmdvalidation.ValidateNetworkSource(deployNetwork); err != nil {
+		return err
 	}
-	// Validate validator count based on mode
-	if deployMode == string(types.ExecutionModeDocker) {
-		if deployValidators < 1 || deployValidators > 100 {
-			return fmt.Errorf("invalid validators: %d (must be 1-100 for docker mode)", deployValidators)
-		}
-	} else if deployMode == string(types.ExecutionModeLocal) {
-		if deployValidators < 1 || deployValidators > 4 {
-			return fmt.Errorf("invalid validators: %d (must be 1-4 for local mode)", deployValidators)
-		}
-	} else {
-		return fmt.Errorf("invalid mode: %s (must be 'docker' or 'local')", deployMode)
+	if err := cmdvalidation.ValidateValidatorsForMode(deployMode, deployValidators); err != nil {
+		return err
 	}
 
 	// Validate port availability for local mode before proceeding

--- a/cmd/devnet-builder/commands/manage/deploy_test.go
+++ b/cmd/devnet-builder/commands/manage/deploy_test.go
@@ -3,7 +3,10 @@ package manage
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestValidateBinaryPath_ValidExecutable(t *testing.T) {
@@ -128,5 +131,77 @@ func TestValidateBinaryPath_PathWithSpaces(t *testing.T) {
 	}
 	if !filepath.IsAbs(result) {
 		t.Errorf("validateBinaryPath() should return absolute path, got: %s", result)
+	}
+}
+
+func TestDeployPreRunInvalidModeStopsRunE(t *testing.T) {
+	cmd := NewDeployCmd()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--mode", "invalid"})
+
+	runCalled := false
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		runCalled = true
+		return nil
+	}
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error for invalid mode")
+	}
+	if !strings.Contains(err.Error(), "invalid mode") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if runCalled {
+		t.Fatalf("RunE should not be called when PreRunE validation fails")
+	}
+}
+
+func TestStartPreRunInvalidModeStopsRunE(t *testing.T) {
+	cmd := NewStartCmd()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--mode", "invalid"})
+
+	runCalled := false
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		runCalled = true
+		return nil
+	}
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error for invalid mode")
+	}
+	if !strings.Contains(err.Error(), "invalid mode") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if runCalled {
+		t.Fatalf("RunE should not be called when PreRunE validation fails")
+	}
+}
+
+func TestUpgradePreRunInvalidVotingPeriodStopsRunE(t *testing.T) {
+	cmd := NewUpgradeCmd()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--voting-period", "not-a-duration"})
+
+	runCalled := false
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		runCalled = true
+		return nil
+	}
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error for invalid voting period")
+	}
+	if !strings.Contains(err.Error(), "invalid voting period") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if runCalled {
+		t.Fatalf("RunE should not be called when PreRunE validation fails")
 	}
 }

--- a/cmd/devnet-builder/commands/manage/start.go
+++ b/cmd/devnet-builder/commands/manage/start.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/altuslabsxyz/devnet-builder/internal/application"
 	"github.com/altuslabsxyz/devnet-builder/internal/application/dto"
+	cmdvalidation "github.com/altuslabsxyz/devnet-builder/internal/cmd/validation"
 	"github.com/altuslabsxyz/devnet-builder/internal/output"
 	"github.com/altuslabsxyz/devnet-builder/types"
 	"github.com/altuslabsxyz/devnet-builder/types/ctxconfig"
@@ -60,7 +61,8 @@ Examples:
 
   # Start with custom health timeout
   devnet-builder start --health-timeout 10m`,
-		RunE: runStart,
+		PreRunE: preRunStart,
+		RunE:    runStart,
 	}
 
 	cmd.Flags().StringVarP(&upMode, "mode", "m", "",
@@ -73,6 +75,13 @@ Examples:
 		"Network repository version. If not specified, uses init version")
 
 	return cmd
+}
+
+func preRunStart(cmd *cobra.Command, args []string) error {
+	if upMode == "" {
+		return nil
+	}
+	return cmdvalidation.ValidateMode(upMode)
 }
 
 func runStart(cmd *cobra.Command, args []string) error {
@@ -92,11 +101,6 @@ func runStart(cmd *cobra.Command, args []string) error {
 	// Apply environment variables
 	if version := os.Getenv("NETWORK_VERSION"); version != "" && !cmd.Flags().Changed("network-version") {
 		upStableVersion = version
-	}
-
-	// Validate mode if specified
-	if upMode != "" && !types.ExecutionMode(upMode).IsValid() {
-		return outputStartErrorWithMode(fmt.Errorf("invalid mode: %s (must be 'docker' or 'local')", upMode), jsonMode)
 	}
 
 	// Initialize service

--- a/cmd/devnet-builder/commands/manage/upgrade.go
+++ b/cmd/devnet-builder/commands/manage/upgrade.go
@@ -15,6 +15,7 @@ import (
 	"github.com/altuslabsxyz/devnet-builder/internal/application"
 	"github.com/altuslabsxyz/devnet-builder/internal/application/dto"
 	"github.com/altuslabsxyz/devnet-builder/internal/application/ports"
+	cmdvalidation "github.com/altuslabsxyz/devnet-builder/internal/cmd/validation"
 	"github.com/altuslabsxyz/devnet-builder/internal/di"
 	"github.com/altuslabsxyz/devnet-builder/internal/infrastructure/binary"
 	"github.com/altuslabsxyz/devnet-builder/internal/infrastructure/cache"
@@ -133,7 +134,8 @@ Resume options (for interrupted upgrades):
 
   # Resume from a specific stage (advanced)
   devnet-builder upgrade --resume --resume-from SwitchingBinary`,
-		RunE: runUpgrade,
+		PreRunE: preRunUpgrade,
+		RunE:    runUpgrade,
 	}
 
 	// Version selection flags
@@ -163,6 +165,27 @@ Resume options (for interrupted upgrades):
 	cmd.Flags().BoolVar(&upgradeShowStatus, "show-status", false, "Show current upgrade state and exit")
 
 	return cmd
+}
+
+func preRunUpgrade(cmd *cobra.Command, args []string) error {
+	if upgradeMode != "" {
+		if err := cmdvalidation.ValidateMode(upgradeMode); err != nil {
+			return err
+		}
+	}
+
+	if _, err := time.ParseDuration(votingPeriod); err != nil {
+		return fmt.Errorf("invalid voting period: %w", err)
+	}
+
+	if upgradeResumeFrom != "" {
+		targetStage := ports.ResumableStage(upgradeResumeFrom)
+		if !isValidStage(targetStage) {
+			return fmt.Errorf("invalid stage: %s", upgradeResumeFrom)
+		}
+	}
+
+	return nil
 }
 
 // UpgradeResultJSON represents the JSON output for the upgrade command.
@@ -256,13 +279,8 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 	resolvedMode := UpgradeExecutionMode(cleanMetadata.ExecutionMode)
 	modeExplicitlySet := false
 	if upgradeMode != "" {
-		switch UpgradeExecutionMode(upgradeMode) {
-		case UpgradeModeDocker, UpgradeModeLocal:
-			resolvedMode = UpgradeExecutionMode(upgradeMode)
-			modeExplicitlySet = true
-		default:
-			return fmt.Errorf("invalid mode %q: must be 'docker' or 'local'", upgradeMode)
-		}
+		resolvedMode = UpgradeExecutionMode(upgradeMode)
+		modeExplicitlySet = true
 	}
 
 	// Mode validation against --image/--binary flags

--- a/cmd/dvb/daemon.go
+++ b/cmd/dvb/daemon.go
@@ -38,7 +38,7 @@ Examples:
 		newDaemonStatusCmd(),
 		newDaemonLogsCmd(),
 		newDaemonWhoAmICmd(),
-		newPluginsCmd(),
+		markDaemonRequired(newPluginsCmd()),
 	)
 
 	return cmd

--- a/cmd/dvb/errors.go
+++ b/cmd/dvb/errors.go
@@ -1,16 +1,13 @@
 // cmd/dvb/errors.go
 package main
 
-import "fmt"
+import cmdvalidation "github.com/altuslabsxyz/devnet-builder/internal/cmd/validation"
 
 // errDaemonNotRunning is the standard error returned when daemon connection is required but unavailable.
-var errDaemonNotRunning = fmt.Errorf("daemon not running - start with: devnetd")
+var errDaemonNotRunning = cmdvalidation.ErrDaemonNotRunning
 
 // requireDaemon returns errDaemonNotRunning if the daemon client is not connected.
 // Usage: if err := requireDaemon(); err != nil { return err }
 func requireDaemon() error {
-	if daemonClient == nil {
-		return errDaemonNotRunning
-	}
-	return nil
+	return cmdvalidation.RequireDaemonConnected(daemonClient != nil)
 }

--- a/cmd/dvb/get.go
+++ b/cmd/dvb/get.go
@@ -44,10 +44,6 @@ Examples:
   dvb get staging/my-devnet`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := requireDaemon(); err != nil {
-				return err
-			}
-
 			var explicitDevnet string
 			if len(args) > 0 {
 				explicitDevnet = args[0]

--- a/cmd/dvb/main.go
+++ b/cmd/dvb/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/altuslabsxyz/devnet-builder/internal/client"
+	cmdvalidation "github.com/altuslabsxyz/devnet-builder/internal/cmd/validation"
 	"github.com/altuslabsxyz/devnet-builder/internal/daemon/types"
 	"github.com/altuslabsxyz/devnet-builder/internal/dvbcontext"
 	"github.com/altuslabsxyz/devnet-builder/internal/output"
@@ -109,6 +110,10 @@ func main() {
 
 			// Skip if standalone mode
 			if standalone {
+				currentContext, _ = dvbcontext.Load()
+				if commandRequiresDaemon(cmd) {
+					return cmdvalidation.RequireDaemonConnected(false)
+				}
 				return nil
 			}
 
@@ -168,6 +173,10 @@ func main() {
 			// Load context (ignore errors, context is optional)
 			currentContext, _ = dvbcontext.Load()
 
+			if commandRequiresDaemon(cmd) {
+				return validateDaemonRequirement(cmd)
+			}
+
 			return nil
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
@@ -192,15 +201,15 @@ func main() {
 		newDaemonCmd(),
 		newUseCmd(),
 		newStatusCmd(),
-		newGetCmd(),
+		markDaemonRequired(newGetCmd()),
 		newDeleteCmd(),
-		newListCmd(),
-		newNodeCmd(),
-		newUpgradeCmd(),
-		newTxCmd(),
-		newGovCmd(),
+		markDaemonRequired(newListCmd()),
+		markDaemonRequired(newNodeCmd()),
+		markDaemonRequired(newUpgradeCmd()),
+		markDaemonRequired(newTxCmd()),
+		markDaemonRequired(newGovCmd()),
 		newGenesisCmd(),
-		newProvisionCmd(),
+		markDaemonRequired(newProvisionCmd()),
 		newConfigCmd(),
 		newCompletionCmd(),
 		newDeprecatedStartCmd(),
@@ -273,10 +282,6 @@ func newListCmd() *cobra.Command {
 		Short:   "List all devnets",
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := requireDaemon(); err != nil {
-				return err
-			}
-
 			devnets, err := daemonClient.ListDevnets(cmd.Context(), namespace)
 			if err != nil {
 				return err

--- a/cmd/dvb/node.go
+++ b/cmd/dvb/node.go
@@ -163,10 +163,6 @@ Examples:
   dvb node list --wide`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := requireDaemon(); err != nil {
-				return err
-			}
-
 			var explicitDevnet string
 			if len(args) > 0 {
 				explicitDevnet = args[0]
@@ -445,10 +441,6 @@ Examples:
   dvb node get my-devnet validator-0`,
 		Args: cobra.RangeArgs(0, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := requireDaemon(); err != nil {
-				return err
-			}
-
 			explicitDevnet, nodeNameArg := resolveNodeArgs(args)
 
 			ns, devnetName, err := resolveWithSuggestions(explicitDevnet, namespace)
@@ -515,10 +507,6 @@ Examples:
   dvb node health my-devnet fullnode-0`,
 		Args: cobra.RangeArgs(0, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := requireDaemon(); err != nil {
-				return err
-			}
-
 			explicitDevnet, nodeNameArg := resolveNodeArgs(args)
 
 			ns, devnetName, err := resolveWithSuggestions(explicitDevnet, namespace)
@@ -578,10 +566,6 @@ Examples:
   dvb node ports my-devnet fullnode-0`,
 		Args: cobra.RangeArgs(0, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := requireDaemon(); err != nil {
-				return err
-			}
-
 			explicitDevnet, nodeNameArg := resolveNodeArgs(args)
 
 			ns, devnetName, err := resolveWithSuggestions(explicitDevnet, namespace)
@@ -672,10 +656,6 @@ Examples:
   dvb node start my-devnet validator-0`,
 		Args: cobra.RangeArgs(0, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := requireDaemon(); err != nil {
-				return err
-			}
-
 			explicitDevnet, nodeNameArg := resolveNodeArgs(args)
 
 			ns, devnetName, err := resolveWithSuggestions(explicitDevnet, namespace)
@@ -794,10 +774,6 @@ Examples:
   dvb node stop my-devnet validator-0`,
 		Args: cobra.RangeArgs(0, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := requireDaemon(); err != nil {
-				return err
-			}
-
 			explicitDevnet, nodeNameArg := resolveNodeArgs(args)
 
 			ns, devnetName, err := resolveWithSuggestions(explicitDevnet, namespace)
@@ -882,10 +858,6 @@ Examples:
   dvb node restart my-devnet validator-0`,
 		Args: cobra.RangeArgs(0, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := requireDaemon(); err != nil {
-				return err
-			}
-
 			explicitDevnet, nodeNameArg := resolveNodeArgs(args)
 
 			ns, devnetName, err := resolveWithSuggestions(explicitDevnet, namespace)
@@ -993,10 +965,6 @@ Examples:
   dvb node exec validator-0 --timeout 60 -- stabled query bank balances cosmos1...`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := requireDaemon(); err != nil {
-				return err
-			}
-
 			// Find the -- separator position
 			dashDashPos := -1
 			for i, arg := range args {

--- a/cmd/dvb/plugins.go
+++ b/cmd/dvb/plugins.go
@@ -52,10 +52,6 @@ Examples:
 
 // runPluginsList lists available network plugins from the daemon
 func runPluginsList(ctx context.Context) error {
-	if err := requireDaemon(); err != nil {
-		return err
-	}
-
 	networks, err := daemonClient.ListNetworks(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list networks: %w", err)

--- a/cmd/dvb/provision.go
+++ b/cmd/dvb/provision.go
@@ -14,6 +14,7 @@ import (
 
 	v1 "github.com/altuslabsxyz/devnet-builder/api/proto/gen/v1"
 	"github.com/altuslabsxyz/devnet-builder/internal/client"
+	cmdvalidation "github.com/altuslabsxyz/devnet-builder/internal/cmd/validation"
 	"github.com/altuslabsxyz/devnet-builder/internal/config"
 	"github.com/altuslabsxyz/devnet-builder/internal/dvbcontext"
 	"github.com/altuslabsxyz/devnet-builder/internal/output"
@@ -74,7 +75,7 @@ Use --list-plugins to see available networks.
 
 Run without arguments for an interactive wizard experience.
 
-Examples:
+		Examples:
   # List available network plugins
   dvb provision --list-plugins
 
@@ -98,6 +99,7 @@ Examples:
   # Preview changes without applying (dry-run)
   dvb provision --name my-devnet --network stable --dry-run
   dvb provision -f devnet.yaml --dry-run`,
+		PreRunE: preRunProvision(opts),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// List plugins mode
 			if opts.listPlugins {
@@ -170,16 +172,42 @@ func detectProvisionMode(opts *provisionOptions) ProvisionMode {
 	return InteractiveMode
 }
 
+func preRunProvision(opts *provisionOptions) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		mode := detectProvisionMode(opts)
+		if mode != FlagMode {
+			return nil
+		}
+
+		return validateFlagModeOptions(opts)
+	}
+}
+
+func validateFlagModeOptions(opts *provisionOptions) error {
+	if !opts.quick && opts.name == "" {
+		return fmt.Errorf("--name is required in flag mode")
+	}
+	if opts.network == "" {
+		return fmt.Errorf("--network is required in flag mode")
+	}
+	if err := cmdvalidation.ValidateAtLeast("validators", opts.validators, 1); err != nil {
+		return err
+	}
+	if err := cmdvalidation.ValidateNonNegative("full-nodes", opts.fullNodes); err != nil {
+		return err
+	}
+	if err := cmdvalidation.ValidateMode(opts.mode); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // runInteractiveMode handles interactive wizard mode
 func runInteractiveMode(ctx context.Context, opts *provisionOptions) error {
 	// Interactive mode requires a TTY
 	if IsNonInteractive() {
 		return fmt.Errorf("interactive wizard requires a terminal\n\nUse flags instead:\n  dvb provision --name my-devnet --network stable\n\nOr use a YAML file:\n  dvb provision -f devnet.yaml\n\nOr use quick mode:\n  dvb provision --quick")
-	}
-
-	// Require daemon to be running
-	if err := requireDaemon(); err != nil {
-		return err
 	}
 
 	// Run the wizard to collect options
@@ -216,11 +244,6 @@ func runInteractiveMode(ctx context.Context, opts *provisionOptions) error {
 
 // runFlagMode handles flag-based provisioning
 func runFlagMode(ctx context.Context, opts *provisionOptions) error {
-	// Require daemon to be running
-	if err := requireDaemon(); err != nil {
-		return err
-	}
-
 	// Quick mode: apply smart defaults for unset values
 	if opts.quick {
 		if opts.name == "" {
@@ -236,23 +259,9 @@ func runFlagMode(ctx context.Context, opts *provisionOptions) error {
 		}
 	}
 
-	// Validate required flags
-	if opts.name == "" {
-		return fmt.Errorf("--name is required in flag mode")
-	}
-	if opts.network == "" {
-		return fmt.Errorf("--network is required in flag mode")
-	}
-
-	// Validate options
-	if opts.validators < 1 {
-		return fmt.Errorf("--validators must be at least 1")
-	}
-	if opts.fullNodes < 0 {
-		return fmt.Errorf("--full-nodes cannot be negative")
-	}
-	if opts.mode != "docker" && opts.mode != "local" {
-		return fmt.Errorf("--mode must be 'docker' or 'local'")
+	// Validate options after quick-mode defaults are applied.
+	if err := validateFlagModeOptions(opts); err != nil {
+		return err
 	}
 
 	// Build devnet spec
@@ -277,11 +286,6 @@ func runFlagMode(ctx context.Context, opts *provisionOptions) error {
 
 // runFileMode handles file-based provisioning
 func runFileMode(ctx context.Context, opts *provisionOptions) error {
-	// Require daemon to be running
-	if err := requireDaemon(); err != nil {
-		return err
-	}
-
 	// Load and validate the YAML file
 	loader := config.NewYAMLLoader()
 	devnets, err := loader.LoadFile(opts.file)

--- a/cmd/dvb/tx.go
+++ b/cmd/dvb/tx.go
@@ -43,10 +43,6 @@ func newTxSubmitCmd() *cobra.Command {
 		Short: "Submit a transaction",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := requireDaemon(); err != nil {
-				return err
-			}
-
 			// Get explicit devnet from args or flag
 			explicitDevnet := devnet
 			if len(args) > 0 {
@@ -112,10 +108,6 @@ func newTxListCmd() *cobra.Command {
 		Aliases: []string{"ls"},
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := requireDaemon(); err != nil {
-				return err
-			}
-
 			// Get explicit devnet from args or flag
 			explicitDevnet := devnet
 			if len(args) > 0 {
@@ -179,10 +171,6 @@ func newTxStatusCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 
-			if err := requireDaemon(); err != nil {
-				return err
-			}
-
 			tx, err := daemonClient.GetTransaction(cmd.Context(), name)
 			if err != nil {
 				return err
@@ -201,10 +189,6 @@ func newTxCancelCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
-
-			if err := requireDaemon(); err != nil {
-				return err
-			}
 
 			tx, err := daemonClient.CancelTransaction(cmd.Context(), name)
 			if err != nil {
@@ -247,10 +231,6 @@ func newGovVoteCmd() *cobra.Command {
 		Short: "Submit a governance vote",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := requireDaemon(); err != nil {
-				return err
-			}
-
 			// Get explicit devnet from args or flag
 			explicitDevnet := devnet
 			if len(args) > 0 {
@@ -314,10 +294,6 @@ func newGovProposeCmd() *cobra.Command {
 		Short: "Submit a governance proposal",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := requireDaemon(); err != nil {
-				return err
-			}
-
 			// Get explicit devnet from args or flag
 			explicitDevnet := devnet
 			if len(args) > 0 {

--- a/cmd/dvb/upgrade.go
+++ b/cmd/dvb/upgrade.go
@@ -50,18 +50,10 @@ func newUpgradeCreateCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 
-			if err := requireDaemon(); err != nil {
-				return err
-			}
-
 			// Resolve devnet from context if not provided
 			ns, devnetName, err := resolveWithSuggestions(devnet, namespace)
 			if err != nil {
 				return err
-			}
-
-			if upgradeName == "" {
-				return fmt.Errorf("--upgrade-name is required")
 			}
 
 			printContextHeader(devnet, currentContext)
@@ -125,10 +117,6 @@ func newUpgradeListCmd() *cobra.Command {
 		Short:   "List upgrades",
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := requireDaemon(); err != nil {
-				return err
-			}
-
 			upgrades, err := daemonClient.ListUpgrades(cmd.Context(), namespace)
 			if err != nil {
 				return err
@@ -183,10 +171,6 @@ func newUpgradeStatusCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 
-			if err := requireDaemon(); err != nil {
-				return err
-			}
-
 			upgrade, err := daemonClient.GetUpgrade(cmd.Context(), namespace, name)
 			if err != nil {
 				return err
@@ -211,10 +195,6 @@ func newUpgradeCancelCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
-
-			if err := requireDaemon(); err != nil {
-				return err
-			}
 
 			upgrade, err := daemonClient.CancelUpgrade(cmd.Context(), namespace, name)
 			if err != nil {
@@ -242,10 +222,6 @@ func newUpgradeRetryCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
-
-			if err := requireDaemon(); err != nil {
-				return err
-			}
 
 			upgrade, err := daemonClient.RetryUpgrade(cmd.Context(), namespace, name)
 			if err != nil {
@@ -276,10 +252,6 @@ func newUpgradeDeleteCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
-
-			if err := requireDaemon(); err != nil {
-				return err
-			}
 
 			if !force && !ShouldSkipConfirm() {
 				fmt.Printf("Are you sure you want to delete upgrade %q? [y/N] ", name)

--- a/cmd/dvb/validation_hooks.go
+++ b/cmd/dvb/validation_hooks.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	cmdvalidation "github.com/altuslabsxyz/devnet-builder/internal/cmd/validation"
+	"github.com/spf13/cobra"
+)
+
+const daemonRequiredAnnotation = "dvb.devnet-builder.io/requires-daemon"
+
+func markDaemonRequired(cmd *cobra.Command) *cobra.Command {
+	if cmd.Annotations == nil {
+		cmd.Annotations = make(map[string]string)
+	}
+	cmd.Annotations[daemonRequiredAnnotation] = "true"
+	return cmd
+}
+
+func commandRequiresDaemon(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Annotations != nil && c.Annotations[daemonRequiredAnnotation] == "true" {
+			return true
+		}
+	}
+	return false
+}
+
+func validateDaemonRequirement(cmd *cobra.Command) error {
+	return cmdvalidation.RequireDaemonConnected(daemonClient != nil)
+}

--- a/cmd/dvb/validation_hooks_test.go
+++ b/cmd/dvb/validation_hooks_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestMarkDaemonRequiredAndLookup(t *testing.T) {
+	parent := markDaemonRequired(&cobra.Command{Use: "parent"})
+	child := &cobra.Command{Use: "child"}
+	parent.AddCommand(child)
+
+	if !commandRequiresDaemon(child) {
+		t.Fatalf("expected child command to inherit daemon requirement")
+	}
+}
+
+func TestValidateDaemonRequirement(t *testing.T) {
+	original := daemonClient
+	daemonClient = nil
+	t.Cleanup(func() {
+		daemonClient = original
+	})
+
+	err := validateDaemonRequirement(&cobra.Command{Use: "any"})
+	if err == nil {
+		t.Fatalf("expected daemon requirement error")
+	}
+	if !strings.Contains(err.Error(), "daemon not running") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPreRunProvisionValidation(t *testing.T) {
+	opts := &provisionOptions{
+		quick:      true,
+		network:    "stable",
+		validators: 1,
+		fullNodes:  0,
+		mode:       "invalid",
+	}
+
+	err := preRunProvision(opts)(&cobra.Command{Use: "provision"}, nil)
+	if err == nil {
+		t.Fatalf("expected invalid mode error")
+	}
+	if !strings.Contains(err.Error(), "invalid mode") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/cmd/validation/validation.go
+++ b/internal/cmd/validation/validation.go
@@ -1,0 +1,79 @@
+package validation
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/altuslabsxyz/devnet-builder/types"
+)
+
+var (
+	// ErrDaemonNotRunning is returned when a command requires daemon connectivity.
+	ErrDaemonNotRunning = errors.New("daemon not running - start with: devnetd")
+)
+
+// ValidateMode validates execution mode values accepted by CLI commands.
+func ValidateMode(mode string) error {
+	if !types.ExecutionMode(mode).IsValid() {
+		return fmt.Errorf("invalid mode: %s (must be 'docker' or 'local')", mode)
+	}
+	return nil
+}
+
+// ValidateNetworkSource validates snapshot source network values.
+func ValidateNetworkSource(network string) error {
+	if !types.NetworkSource(network).IsValid() {
+		return fmt.Errorf("invalid network: %s (must be 'mainnet' or 'testnet')", network)
+	}
+	return nil
+}
+
+// ValidateValidatorsForMode validates validator count with mode-specific bounds.
+func ValidateValidatorsForMode(mode string, validators int) error {
+	switch types.ExecutionMode(mode) {
+	case types.ExecutionModeDocker:
+		if validators < 1 || validators > 100 {
+			return fmt.Errorf("invalid validators: %d (must be 1-100 for docker mode)", validators)
+		}
+	case types.ExecutionModeLocal:
+		if validators < 1 || validators > 4 {
+			return fmt.Errorf("invalid validators: %d (must be 1-4 for local mode)", validators)
+		}
+	default:
+		return ValidateMode(mode)
+	}
+
+	return nil
+}
+
+// ValidateValidatorsRange validates validator count against a fixed range.
+func ValidateValidatorsRange(validators, min, max int) error {
+	if validators < min || validators > max {
+		return fmt.Errorf("invalid validators: %d (must be %d-%d)", validators, min, max)
+	}
+	return nil
+}
+
+// ValidateAtLeast validates a numeric value has a minimum.
+func ValidateAtLeast(flagName string, value, min int) error {
+	if value < min {
+		return fmt.Errorf("--%s must be at least %d", flagName, min)
+	}
+	return nil
+}
+
+// ValidateNonNegative validates a numeric value is non-negative.
+func ValidateNonNegative(flagName string, value int) error {
+	if value < 0 {
+		return fmt.Errorf("--%s cannot be negative", flagName)
+	}
+	return nil
+}
+
+// RequireDaemonConnected validates daemon connectivity for daemon-dependent commands.
+func RequireDaemonConnected(connected bool) error {
+	if !connected {
+		return ErrDaemonNotRunning
+	}
+	return nil
+}

--- a/internal/cmd/validation/validation_test.go
+++ b/internal/cmd/validation/validation_test.go
@@ -1,0 +1,121 @@
+package validation
+
+import "testing"
+
+func TestValidateMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    string
+		wantErr bool
+	}{
+		{name: "docker", mode: "docker", wantErr: false},
+		{name: "local", mode: "local", wantErr: false},
+		{name: "invalid", mode: "k8s", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateMode(tt.mode)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateMode() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateNetworkSource(t *testing.T) {
+	tests := []struct {
+		name    string
+		network string
+		wantErr bool
+	}{
+		{name: "mainnet", network: "mainnet", wantErr: false},
+		{name: "testnet", network: "testnet", wantErr: false},
+		{name: "invalid", network: "devnet", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateNetworkSource(tt.network)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateNetworkSource() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateValidatorsForMode(t *testing.T) {
+	tests := []struct {
+		name       string
+		mode       string
+		validators int
+		wantErr    bool
+	}{
+		{name: "docker valid min", mode: "docker", validators: 1, wantErr: false},
+		{name: "docker valid max", mode: "docker", validators: 100, wantErr: false},
+		{name: "docker invalid", mode: "docker", validators: 101, wantErr: true},
+		{name: "local valid min", mode: "local", validators: 1, wantErr: false},
+		{name: "local valid max", mode: "local", validators: 4, wantErr: false},
+		{name: "local invalid", mode: "local", validators: 5, wantErr: true},
+		{name: "mode invalid", mode: "k8s", validators: 3, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateValidatorsForMode(tt.mode, tt.validators)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateValidatorsForMode() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateValidatorsRange(t *testing.T) {
+	tests := []struct {
+		name       string
+		validators int
+		min        int
+		max        int
+		wantErr    bool
+	}{
+		{name: "in range", validators: 2, min: 1, max: 4, wantErr: false},
+		{name: "below min", validators: 0, min: 1, max: 4, wantErr: true},
+		{name: "above max", validators: 5, min: 1, max: 4, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateValidatorsRange(tt.validators, tt.min, tt.max)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateValidatorsRange() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateAtLeast(t *testing.T) {
+	if err := ValidateAtLeast("validators", 1, 1); err != nil {
+		t.Fatalf("ValidateAtLeast() unexpected error: %v", err)
+	}
+	if err := ValidateAtLeast("validators", 0, 1); err == nil {
+		t.Fatalf("ValidateAtLeast() expected error for below minimum")
+	}
+}
+
+func TestValidateNonNegative(t *testing.T) {
+	if err := ValidateNonNegative("full-nodes", 0); err != nil {
+		t.Fatalf("ValidateNonNegative() unexpected error: %v", err)
+	}
+	if err := ValidateNonNegative("full-nodes", -1); err == nil {
+		t.Fatalf("ValidateNonNegative() expected error for negative value")
+	}
+}
+
+func TestRequireDaemonConnected(t *testing.T) {
+	if err := RequireDaemonConnected(true); err != nil {
+		t.Fatalf("RequireDaemonConnected(true) unexpected error: %v", err)
+	}
+	if err := RequireDaemonConnected(false); err == nil {
+		t.Fatalf("RequireDaemonConnected(false) expected error")
+	}
+}


### PR DESCRIPTION
## Enhancement Description
Make CLI validation fail-fast by moving checks to `PreRunE` and centralizing shared validators.

## Summary
This PR moves validation out of `RunE` and into `PreRunE` (or parent persistent hooks where appropriate), so invalid input fails before expensive initialization.
It also introduces a shared validation package for consistent error rules/messages.

## Scope
- Move validations from `RunE` to `PreRunE` in key command paths.
- Centralize reusable checks under `internal/cmd/validation`.
- Promote daemon requirement checks in `dvb` to root `PersistentPreRunE` via command annotations.
- Remove redundant manual required-flag checks where `MarkFlagRequired` already enforces them.
- Keep CLI behavior/flags/output semantics unchanged except validation timing.

## Main Changes
- Added `internal/cmd/validation`:
  - mode validation
  - network validation
  - validator count/range validation
  - daemon connected requirement
- `devnet-builder` command updates:
  - `manage/deploy`: added `PreRunE` validation and shared validators
  - `core/init`: added `PreRunE` validation and shared validators
  - `manage/start`: moved mode validation to `PreRunE`
  - `manage/upgrade`: moved mode/voting-period/resume-stage validation to `PreRunE`
- `dvb` command updates:
  - added daemon-required annotation + root persistent check
  - removed repeated inline `requireDaemon()` checks from daemon-dependent subcommands
  - `provision`: added pre-run validation path for flag mode and centralized option validation
  - removed redundant manual `--upgrade-name` empty check in upgrade create (already covered by `MarkFlagRequired`)
- `.gitignore` fix:
  - changed `devnet-builder` ignore rule to `/devnet-builder` to avoid ignoring `cmd/devnet-builder/**` source files.

## Why
- Invalid input now fails early (before service init/config/network-heavy paths).
- Validation logic is now consistent and easier to test/review.
- Daemon dependency enforcement is centralized instead of duplicated across many handlers.

## Validation
Executed:
- `go test ./internal/cmd/validation/...`
- `go test ./cmd/devnet-builder/commands/manage/...`
- `go test ./cmd/devnet-builder/commands/core/...`
- `go test ./cmd/dvb/...`

## Non-Goals
- No new flags.
- No CLI UX/contract changes beyond fail-fast timing.
- No business logic/flow redesign outside validation placement and reuse.

## Risk & Mitigation
- Risk: subtle ordering regressions with Cobra hooks.
- Mitigation: validation moved with minimal logic changes, error semantics preserved, and unit coverage added for shared validators and hook behavior.
