### PR TITLE
refactor(config): unify validator-count rules across modes 

### DIFF
--- a/cmd/devnet-builder/commands/manage/deploy.go
+++ b/cmd/devnet-builder/commands/manage/deploy.go
@@ -293,17 +293,9 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	if !types.NetworkSource(deployNetwork).IsValid() {
 		return fmt.Errorf("invalid network: %s (must be 'mainnet' or 'testnet')", deployNetwork)
 	}
-	// Validate validator count based on mode
-	if deployMode == string(types.ExecutionModeDocker) {
-		if deployValidators < 1 || deployValidators > 100 {
-			return fmt.Errorf("invalid validators: %d (must be 1-100 for docker mode)", deployValidators)
-		}
-	} else if deployMode == string(types.ExecutionModeLocal) {
-		if deployValidators < 1 || deployValidators > 4 {
-			return fmt.Errorf("invalid validators: %d (must be 1-4 for local mode)", deployValidators)
-		}
-	} else {
-		return fmt.Errorf("invalid mode: %s (must be 'docker' or 'local')", deployMode)
+	// Validate validator count using shared mode-aware constraints.
+	if err := config.ValidateValidatorCount(deployMode, deployValidators); err != nil {
+		return err
 	}
 
 	// Validate port availability for local mode before proceeding

--- a/cmd/dvb/provision.go
+++ b/cmd/dvb/provision.go
@@ -170,6 +170,26 @@ func detectProvisionMode(opts *provisionOptions) ProvisionMode {
 	return InteractiveMode
 }
 
+func validateFlagModeOptions(opts *provisionOptions) error {
+	// Validate required flags
+	if opts.name == "" {
+		return fmt.Errorf("--name is required in flag mode")
+	}
+	if opts.network == "" {
+		return fmt.Errorf("--network is required in flag mode")
+	}
+
+	// Validate options
+	if err := config.ValidateValidatorCount(opts.mode, opts.validators); err != nil {
+		return err
+	}
+	if opts.fullNodes < 0 {
+		return fmt.Errorf("--full-nodes cannot be negative")
+	}
+
+	return nil
+}
+
 // runInteractiveMode handles interactive wizard mode
 func runInteractiveMode(ctx context.Context, opts *provisionOptions) error {
 	// Interactive mode requires a TTY
@@ -236,23 +256,8 @@ func runFlagMode(ctx context.Context, opts *provisionOptions) error {
 		}
 	}
 
-	// Validate required flags
-	if opts.name == "" {
-		return fmt.Errorf("--name is required in flag mode")
-	}
-	if opts.network == "" {
-		return fmt.Errorf("--network is required in flag mode")
-	}
-
-	// Validate options
-	if opts.validators < 1 {
-		return fmt.Errorf("--validators must be at least 1")
-	}
-	if opts.fullNodes < 0 {
-		return fmt.Errorf("--full-nodes cannot be negative")
-	}
-	if opts.mode != "docker" && opts.mode != "local" {
-		return fmt.Errorf("--mode must be 'docker' or 'local'")
+	if err := validateFlagModeOptions(opts); err != nil {
+		return err
 	}
 
 	// Build devnet spec

--- a/cmd/dvb/provision_test.go
+++ b/cmd/dvb/provision_test.go
@@ -122,6 +122,60 @@ func TestDetectProvisionMode(t *testing.T) {
 	}
 }
 
+func TestValidateFlagModeOptions_ValidatorBounds(t *testing.T) {
+	tests := []struct {
+		name       string
+		opts       *provisionOptions
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name: "docker allows up to 100",
+			opts: &provisionOptions{
+				name:       "devnet-a",
+				network:    "stable",
+				mode:       "docker",
+				validators: 100,
+			},
+			wantErr: false,
+		},
+		{
+			name: "local rejects above 4",
+			opts: &provisionOptions{
+				name:       "devnet-a",
+				network:    "stable",
+				mode:       "local",
+				validators: 5,
+			},
+			wantErr:    true,
+			errContain: "1-4 for local mode",
+		},
+		{
+			name: "docker rejects above 100",
+			opts: &provisionOptions{
+				name:       "devnet-a",
+				network:    "stable",
+				mode:       "docker",
+				validators: 101,
+			},
+			wantErr:    true,
+			errContain: "1-100 for docker mode",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateFlagModeOptions(tt.opts)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateFlagModeOptions() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.errContain != "" && err != nil && !strings.Contains(err.Error(), tt.errContain) {
+				t.Fatalf("expected error containing %q, got %q", tt.errContain, err.Error())
+			}
+		})
+	}
+}
+
 func TestProvisionOptions_NoWaitFlag(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/config/interactive.go
+++ b/internal/config/interactive.go
@@ -200,11 +200,20 @@ func (s *InteractiveSetup) promptNetworkSource(cfg *FileConfig) (string, error) 
 	return result, nil
 }
 
-// promptValidators prompts the user to enter validators count (1-4).
+// promptValidators prompts the user to enter validators count using mode-aware bounds.
 func (s *InteractiveSetup) promptValidators(cfg *FileConfig) (int, error) {
 	defaultValue := "4"
 	if cfg.Validators != nil {
 		defaultValue = strconv.Itoa(*cfg.Validators)
+	}
+
+	mode := ""
+	if cfg.ExecutionMode != nil {
+		mode = string(*cfg.ExecutionMode)
+	}
+	min, max, resolvedMode, err := ValidatorCountRangeForMode(mode)
+	if err != nil {
+		return 0, err
 	}
 
 	validate := func(input string) error {
@@ -212,14 +221,14 @@ func (s *InteractiveSetup) promptValidators(cfg *FileConfig) (int, error) {
 		if err != nil {
 			return fmt.Errorf("please enter a number")
 		}
-		if val < 1 || val > 4 {
-			return fmt.Errorf("validators must be between 1 and 4")
+		if err := ValidateValidatorCount(mode, val); err != nil {
+			return err
 		}
 		return nil
 	}
 
 	prompt := promptui.Prompt{
-		Label:    "Number of validators (1-4)",
+		Label:    fmt.Sprintf("Number of validators (%d-%d for %s mode)", min, max, resolvedMode),
 		Default:  defaultValue,
 		Validate: validate,
 		Templates: &promptui.PromptTemplates{

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -21,14 +21,14 @@ func (c *EffectiveConfig) Validate() error {
 		}
 	}
 
-	// Validate validators
-	if c.Validators.Value < 1 || c.Validators.Value > 4 {
-		return fmt.Errorf("invalid validators: %d (must be 1-4)", c.Validators.Value)
-	}
-
 	// Validate mode using canonical type validation
 	if !types.ExecutionMode(c.Mode.Value).IsValid() {
 		return fmt.Errorf("invalid mode: %s (must be 'docker' or 'local')", c.Mode.Value)
+	}
+
+	// Validate validators with mode-aware constraints.
+	if err := ValidateValidatorCount(c.Mode.Value, c.Validators.Value); err != nil {
+		return err
 	}
 
 	// Validate accounts
@@ -56,17 +56,21 @@ func ValidateFileConfig(cfg *FileConfig) error {
 	// Note: BlockchainNetwork validation is deferred until modules are registered.
 	// This allows config loading to happen before network module init() calls.
 
-	// Validate validators if set
-	if cfg.Validators != nil {
-		if *cfg.Validators < 1 || *cfg.Validators > 4 {
-			return fmt.Errorf("invalid validators in config file: %d (must be 1-4)", *cfg.Validators)
-		}
-	}
-
 	// Validate mode if set using canonical type validation
 	if cfg.ExecutionMode != nil {
 		if !types.ExecutionMode(*cfg.ExecutionMode).IsValid() {
 			return fmt.Errorf("invalid mode in config file: %s (must be 'docker' or 'local')", *cfg.ExecutionMode)
+		}
+	}
+
+	// Validate validators if set using mode-aware constraints.
+	if cfg.Validators != nil {
+		mode := ""
+		if cfg.ExecutionMode != nil {
+			mode = string(*cfg.ExecutionMode)
+		}
+		if err := ValidateValidatorCount(mode, *cfg.Validators); err != nil {
+			return err
 		}
 	}
 

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/altuslabsxyz/devnet-builder/types"
+)
+
+func TestValidateFileConfig_ValidatorCountByMode(t *testing.T) {
+	docker := types.ExecutionModeDocker
+	local := types.ExecutionModeLocal
+
+	tests := []struct {
+		name       string
+		cfg        *FileConfig
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name: "docker allows 100",
+			cfg: &FileConfig{
+				ExecutionMode: &docker,
+				Validators:    intPtr(100),
+			},
+			wantErr: false,
+		},
+		{
+			name: "local rejects above 4",
+			cfg: &FileConfig{
+				ExecutionMode: &local,
+				Validators:    intPtr(5),
+			},
+			wantErr:    true,
+			errContain: "1-4 for local mode",
+		},
+		{
+			name: "empty mode defaults docker",
+			cfg: &FileConfig{
+				Validators: intPtr(50),
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid mode rejected",
+			cfg: &FileConfig{
+				ExecutionMode: executionModePtr("k8s"),
+				Validators:    intPtr(2),
+			},
+			wantErr:    true,
+			errContain: "invalid mode in config file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateFileConfig(tt.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateFileConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.errContain != "" && err != nil && !strings.Contains(err.Error(), tt.errContain) {
+				t.Fatalf("expected error to contain %q, got %q", tt.errContain, err.Error())
+			}
+		})
+	}
+}
+
+func TestEffectiveConfigValidate_ValidatorCountByMode(t *testing.T) {
+	cfg := NewEffectiveConfig("/tmp")
+	cfg.BlockchainNetwork = NewStringValue("")
+	cfg.Mode = NewStringValue("docker")
+	cfg.Validators = NewIntValue(100)
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() should pass for docker validators=100: %v", err)
+	}
+
+	cfg.Mode = NewStringValue("local")
+	cfg.Validators = NewIntValue(5)
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("Validate() should fail for local validators=5")
+	}
+}
+
+func intPtr(v int) *int {
+	return &v
+}
+
+func executionModePtr(v string) *types.ExecutionMode {
+	mode := types.ExecutionMode(v)
+	return &mode
+}

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/altuslabsxyz/devnet-builder/types"
+)
+
+const (
+	// ValidatorCountMin is the minimum validators count for all modes.
+	ValidatorCountMin = 1
+	// ValidatorCountMaxLocal is the maximum validators count for local mode.
+	ValidatorCountMaxLocal = 4
+	// ValidatorCountMaxDocker is the maximum validators count for docker mode.
+	ValidatorCountMaxDocker = 100
+)
+
+// ValidatorCountRangeForMode returns validator bounds for the given mode.
+// Empty mode defaults to docker mode.
+func ValidatorCountRangeForMode(mode string) (min int, max int, resolvedMode string, err error) {
+	m := types.ExecutionMode(mode)
+	if m == "" {
+		m = types.ExecutionModeDocker
+	}
+
+	switch m {
+	case types.ExecutionModeLocal:
+		return ValidatorCountMin, ValidatorCountMaxLocal, string(types.ExecutionModeLocal), nil
+	case types.ExecutionModeDocker:
+		return ValidatorCountMin, ValidatorCountMaxDocker, string(types.ExecutionModeDocker), nil
+	default:
+		return 0, 0, "", fmt.Errorf("invalid mode: %s (must be 'docker' or 'local')", mode)
+	}
+}
+
+// ValidateValidatorCount validates validators count using mode-aware constraints.
+// Empty mode defaults to docker mode.
+func ValidateValidatorCount(mode string, validators int) error {
+	min, max, resolvedMode, err := ValidatorCountRangeForMode(mode)
+	if err != nil {
+		return err
+	}
+
+	if validators < min || validators > max {
+		return fmt.Errorf("invalid validators: %d (must be %d-%d for %s mode)", validators, min, max, resolvedMode)
+	}
+
+	return nil
+}

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -1,0 +1,64 @@
+package config
+
+import "testing"
+
+func TestValidateValidatorCount(t *testing.T) {
+	tests := []struct {
+		name       string
+		mode       string
+		validators int
+		wantErr    bool
+	}{
+		{name: "docker min", mode: "docker", validators: 1, wantErr: false},
+		{name: "docker max", mode: "docker", validators: 100, wantErr: false},
+		{name: "docker below min", mode: "docker", validators: 0, wantErr: true},
+		{name: "docker above max", mode: "docker", validators: 101, wantErr: true},
+		{name: "local min", mode: "local", validators: 1, wantErr: false},
+		{name: "local max", mode: "local", validators: 4, wantErr: false},
+		{name: "local below min", mode: "local", validators: 0, wantErr: true},
+		{name: "local above max", mode: "local", validators: 5, wantErr: true},
+		{name: "empty mode defaults docker", mode: "", validators: 10, wantErr: false},
+		{name: "invalid mode", mode: "kubernetes", validators: 2, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateValidatorCount(tt.mode, tt.validators)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateValidatorCount(%q, %d) error = %v, wantErr %v", tt.mode, tt.validators, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidatorCountRangeForMode(t *testing.T) {
+	tests := []struct {
+		name         string
+		mode         string
+		wantMin      int
+		wantMax      int
+		wantResolved string
+		wantErr      bool
+	}{
+		{name: "docker", mode: "docker", wantMin: 1, wantMax: 100, wantResolved: "docker"},
+		{name: "local", mode: "local", wantMin: 1, wantMax: 4, wantResolved: "local"},
+		{name: "empty defaults docker", mode: "", wantMin: 1, wantMax: 100, wantResolved: "docker"},
+		{name: "invalid", mode: "k8s", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			min, max, resolvedMode, err := ValidatorCountRangeForMode(tt.mode)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidatorCountRangeForMode(%q) error = %v, wantErr %v", tt.mode, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if min != tt.wantMin || max != tt.wantMax || resolvedMode != tt.wantResolved {
+				t.Fatalf("ValidatorCountRangeForMode(%q) = (%d, %d, %q), want (%d, %d, %q)",
+					tt.mode, min, max, resolvedMode, tt.wantMin, tt.wantMax, tt.wantResolved)
+			}
+		})
+	}
+}

--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -115,12 +115,16 @@ func (s *YAMLDevnetSpec) Validate() error {
 		errs = append(errs, "spec.network is required")
 	}
 
-	if s.Validators < 1 {
-		errs = append(errs, "spec.validators must be at least 1")
+	modeValid := true
+	if s.Mode != "" && s.Mode != "docker" && s.Mode != "local" {
+		modeValid = false
+		errs = append(errs, fmt.Sprintf("spec.mode must be 'docker' or 'local', got %q", s.Mode))
 	}
 
-	if s.Mode != "" && s.Mode != "docker" && s.Mode != "local" {
-		errs = append(errs, fmt.Sprintf("spec.mode must be 'docker' or 'local', got %q", s.Mode))
+	if modeValid {
+		if err := ValidateValidatorCount(s.Mode, s.Validators); err != nil {
+			errs = append(errs, fmt.Sprintf("spec.validators %s", err.Error()))
+		}
 	}
 
 	if s.NetworkType != "" && s.NetworkType != "mainnet" && s.NetworkType != "testnet" {

--- a/internal/config/yaml_config_test.go
+++ b/internal/config/yaml_config_test.go
@@ -104,6 +104,40 @@ func TestYAMLDevnet_Validate_InvalidValidators(t *testing.T) {
 	}
 }
 
+func TestYAMLDevnet_Validate_DockerValidatorsUpperBound(t *testing.T) {
+	devnet := YAMLDevnet{
+		APIVersion: "devnet.lagos/v1",
+		Kind:       "Devnet",
+		Metadata:   YAMLMetadata{Name: "test"},
+		Spec: YAMLDevnetSpec{
+			Network:    "stable",
+			Mode:       "docker",
+			Validators: 100,
+		},
+	}
+
+	if err := devnet.Validate(); err != nil {
+		t.Fatalf("Validate() failed for docker validators=100: %v", err)
+	}
+}
+
+func TestYAMLDevnet_Validate_LocalValidatorsUpperBound(t *testing.T) {
+	devnet := YAMLDevnet{
+		APIVersion: "devnet.lagos/v1",
+		Kind:       "Devnet",
+		Metadata:   YAMLMetadata{Name: "test"},
+		Spec: YAMLDevnetSpec{
+			Network:    "stable",
+			Mode:       "local",
+			Validators: 5,
+		},
+	}
+
+	if err := devnet.Validate(); err == nil {
+		t.Fatalf("Validate() should fail for local validators=5")
+	}
+}
+
 func TestYAMLDevnetNamespace(t *testing.T) {
 	yamlContent := `
 apiVersion: devnet.lagos/v1

--- a/internal/config/yaml_validator.go
+++ b/internal/config/yaml_validator.go
@@ -47,8 +47,8 @@ type YAMLValidator struct {
 // NewYAMLValidator creates a new validator with default settings
 func NewYAMLValidator() *YAMLValidator {
 	return &YAMLValidator{
-		MaxValidators: 4,
-		MinValidators: 1,
+		MaxValidators: ValidatorCountMaxLocal,
+		MinValidators: ValidatorCountMin,
 		MaxFullNodes:  10,
 		ValidModes:    []string{"docker", "local"},
 	}
@@ -104,25 +104,8 @@ func (v *YAMLValidator) Validate(devnet *YAMLDevnet) *ValidationResult {
 		})
 	}
 
-	// Validate spec.validators
-	if devnet.Spec.Validators < v.MinValidators || devnet.Spec.Validators > v.MaxValidators {
-		result.Valid = false
-		result.Errors = append(result.Errors, ValidationError{
-			Field:   "spec.validators",
-			Message: fmt.Sprintf("must be between %d and %d, got %d", v.MinValidators, v.MaxValidators, devnet.Spec.Validators),
-		})
-	}
-
-	// Validate spec.fullNodes
-	if devnet.Spec.FullNodes < 0 || devnet.Spec.FullNodes > v.MaxFullNodes {
-		result.Valid = false
-		result.Errors = append(result.Errors, ValidationError{
-			Field:   "spec.fullNodes",
-			Message: fmt.Sprintf("must be between 0 and %d, got %d", v.MaxFullNodes, devnet.Spec.FullNodes),
-		})
-	}
-
 	// Validate spec.mode if provided
+	modeValid := true
 	if devnet.Spec.Mode != "" {
 		validMode := false
 		for _, mode := range v.ValidModes {
@@ -133,11 +116,32 @@ func (v *YAMLValidator) Validate(devnet *YAMLDevnet) *ValidationResult {
 		}
 		if !validMode {
 			result.Valid = false
+			modeValid = false
 			result.Errors = append(result.Errors, ValidationError{
 				Field:   "spec.mode",
 				Message: fmt.Sprintf("must be 'docker' or 'local', got %q", devnet.Spec.Mode),
 			})
 		}
+	}
+
+	// Validate spec.validators using shared mode-aware constraints.
+	if modeValid {
+		if err := ValidateValidatorCount(devnet.Spec.Mode, devnet.Spec.Validators); err != nil {
+			result.Valid = false
+			result.Errors = append(result.Errors, ValidationError{
+				Field:   "spec.validators",
+				Message: err.Error(),
+			})
+		}
+	}
+
+	// Validate spec.fullNodes
+	if devnet.Spec.FullNodes < 0 || devnet.Spec.FullNodes > v.MaxFullNodes {
+		result.Valid = false
+		result.Errors = append(result.Errors, ValidationError{
+			Field:   "spec.fullNodes",
+			Message: fmt.Sprintf("must be between 0 and %d, got %d", v.MaxFullNodes, devnet.Spec.FullNodes),
+		})
 	}
 
 	// Validate spec.networkType if provided

--- a/internal/config/yaml_validator_test.go
+++ b/internal/config/yaml_validator_test.go
@@ -124,6 +124,7 @@ func TestYAMLValidator_Validate_InvalidValidatorsCount(t *testing.T) {
 		Metadata:   YAMLMetadata{Name: "test"},
 		Spec: YAMLDevnetSpec{
 			Network:    "stable",
+			Mode:       "local",
 			Validators: 10, // exceeds max of 4
 		},
 	}
@@ -135,13 +136,13 @@ func TestYAMLValidator_Validate_InvalidValidatorsCount(t *testing.T) {
 	}
 	foundError := false
 	for _, err := range result.Errors {
-		if err.Field == "spec.validators" && strings.Contains(err.Message, "between 1 and 4") {
+		if err.Field == "spec.validators" && strings.Contains(err.Message, "1-4 for local mode") {
 			foundError = true
 			break
 		}
 	}
 	if !foundError {
-		t.Errorf("Validate() should contain error about validators between 1 and 4, got: %v", result.Errors)
+		t.Errorf("Validate() should contain local-mode validator limit error, got: %v", result.Errors)
 	}
 }
 
@@ -379,12 +380,31 @@ func TestYAMLValidator_Validate_ZeroValidators(t *testing.T) {
 	}
 	foundError := false
 	for _, err := range result.Errors {
-		if err.Field == "spec.validators" && strings.Contains(err.Message, "between 1 and 4") {
+		if err.Field == "spec.validators" && strings.Contains(err.Message, "invalid validators") {
 			foundError = true
 			break
 		}
 	}
 	if !foundError {
 		t.Errorf("Validate() should contain error about validators, got: %v", result.Errors)
+	}
+}
+
+func TestYAMLValidator_Validate_DockerAllowsUpTo100(t *testing.T) {
+	v := NewYAMLValidator()
+	devnet := &YAMLDevnet{
+		APIVersion: SupportedAPIVersion,
+		Kind:       SupportedKind,
+		Metadata:   YAMLMetadata{Name: "test"},
+		Spec: YAMLDevnetSpec{
+			Network:    "stable",
+			Mode:       "docker",
+			Validators: 100,
+		},
+	}
+
+	result := v.Validate(devnet)
+	if !result.Valid {
+		t.Fatalf("Validate() should pass for docker validators=100, errors: %v", result.Errors)
 	}
 }


### PR DESCRIPTION
## Enhancement Description
Unify validator count rules across YAML/TOML/CLI paths to prevent late runtime failures and inconsistent behavior.

## Summary
This PR introduces a single source of truth for validator count validation and applies it consistently across config and CLI entry points.

Previously, validator checks differed by path:
- `deploy` used mode-aware bounds (`docker: 1-100`, `local: 1-4`)
- some config/YAML paths effectively enforced `1-4` regardless of mode
- `dvb provision` had no upper bound check in flag mode

Now all relevant paths use one shared validator rule.

## What Changed

### 1) SSOT validator function
Added shared mode-aware validation in:
- `internal/config/validator.go`
- `internal/config/validator_test.go`

Rules:
- `local`: `1-4`
- `docker`: `1-100`
- empty mode defaults to `docker`

### 2) Replaced inconsistent call sites with SSOT
Updated:
- `internal/config/validate.go`
  - `EffectiveConfig.Validate()` now validates validator count by mode
  - `ValidateFileConfig()` now validates validator count by mode (when mode is set; defaults to docker otherwise)
- `internal/config/yaml_validator.go`
- `internal/config/yaml_config.go`
- `cmd/devnet-builder/commands/manage/deploy.go`
- `cmd/dvb/provision.go`

### 3) Interactive path consistency
Updated interactive validator prompt to use the same mode-aware bounds:
- `internal/config/interactive.go`

### 4) Tests
Added/updated tests:
- `internal/config/validate_test.go`
- `internal/config/validator_test.go`
- `internal/config/yaml_validator_test.go`
- `internal/config/yaml_config_test.go`
- `cmd/dvb/provision_test.go`

## Why This Is Needed
This is a consistency bugfix, not a semantic change:
- the documented/runtime intent already included mode-specific bounds
- validation behavior differed by entry point
- invalid config could pass one path and fail later after expensive provisioning steps

## Behavior Notes / Regression Impact
This may tighten validation for users who previously relied on permissive or inconsistent paths.
Example: values that passed some YAML/TOML flows but violate mode-specific constraints now fail early with consistent errors.

## Validation Performed
- `go test ./internal/config/...`
- `go test ./cmd/devnet-builder/commands/manage/...`
- `go test ./cmd/dvb/...`
- `go test ./...`

`golangci-lint run` was also executed; repository has existing baseline lint issues outside this PR scope.
