### PR TITLE
test(ci): add compile-only CI guard for broken test regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,9 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
+      - name: Compile test packages only
+        run: go test ./... -run='^$'
+
       - name: Run tests with race detection
         run: go test -p 1 -race -v ./...
 


### PR DESCRIPTION
## Enhancement Description
Prevent silent test breakages by adding a compile-only test gate in CI.

## Summary
This PR adds a fast compile-only `go test` guard so test compilation regressions fail immediately in CI.

Previously, compile regressions could slip through:
- some CI paths emphasized runtime execution and could miss compile-only failures
- test package breakages were caught later than necessary

Now CI always validates that test code compiles even when runtime-heavy paths are skipped.

## What Changed

### 1) Added compile-only test gate to CI
Updated:
- `.github/workflows/ci.yml`

Guard command:
- `go test ./... -run='^$'`

### 2) Kept runtime test behavior unchanged
- no runtime test semantics were altered
- this adds an early safety net before heavier jobs

### 3) Improved failure feedback timing
- compile errors are surfaced in the first CI stage
- reduces turnaround time for test-related fixes

### 4) Tests
Validation is CI-focused for this change.

## Why This Is Needed
This is a CI reliability improvement.
Compile-time test failures should fail fast and predictably.

## Behavior Notes / Regression Impact
No product runtime behavior change.
Only CI/test pipeline behavior is tightened.

## Validation Performed
- `go test ./... -run='^$'`
- CI workflow run confirming compile-only gate execution
