### PR TITLE
test(daemon): enable goleak-based goroutine leak detection harness

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -235,6 +235,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.39.0 // indirect
 	go.opentelemetry.io/otel/trace v1.39.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
+	go.uber.org/goleak v1.3.0 // indirect
 	go.uber.org/mock v0.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect

--- a/internal/daemon/controller/main_test.go
+++ b/internal/daemon/controller/main_test.go
@@ -1,0 +1,11 @@
+package controller
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, goleak.IgnoreCurrent())
+}

--- a/internal/daemon/runtime/main_test.go
+++ b/internal/daemon/runtime/main_test.go
@@ -1,0 +1,11 @@
+package runtime
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, goleak.IgnoreCurrent())
+}

--- a/internal/daemon/runtime/service_launchd_test.go
+++ b/internal/daemon/runtime/service_launchd_test.go
@@ -17,8 +17,8 @@ func TestRenderPlist(t *testing.T) {
 		Command:          []string{"/usr/bin/stabled", "start", "--home", "/data/node0"},
 		WorkingDirectory: "/data/node0",
 		Environment: map[string]string{
-			"HOME":   "/data/node0",
-			"MYVAR":  "myval",
+			"HOME":  "/data/node0",
+			"MYVAR": "myval",
 		},
 		StdoutPath:       "/var/log/testnode.log",
 		StderrPath:       "/var/log/testnode.err",

--- a/internal/daemon/server/main_test.go
+++ b/internal/daemon/server/main_test.go
@@ -1,0 +1,17 @@
+package server
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(
+		m,
+		goleak.IgnoreCurrent(),
+		// StreamProvisionLogs can outlive test cancellation when channel-close
+		// paths are exercised in isolated goroutines.
+		goleak.IgnoreTopFunction("github.com/altuslabsxyz/devnet-builder/internal/daemon/server.(*DevnetService).StreamProvisionLogs"),
+	)
+}


### PR DESCRIPTION
## Enhancement Description
Enable goleak-based goroutine leak detection in daemon test harnesses to prevent cleanup regressions.

## Summary
This PR adds `goleak.VerifyTestMain` to key daemon packages and applies a minimal allowlist for known safe exceptions.

Previously, goroutine leaks could pass silently in concurrency-heavy packages:
- lifecycle cleanup regressions were harder to catch
- leak detection was not consistently enforced in daemon tests

Now leak checks run automatically in targeted test packages.

## What Changed

### 1) Added goleak TestMain harnesses
Added:
- `internal/daemon/controller/main_test.go`
- `internal/daemon/server/main_test.go`
- `internal/daemon/runtime/main_test.go`

### 2) Added scoped allowlist for known server test path
- allowlisted known safe/expected goroutine path in server test harness
- kept allowlist narrow to avoid masking new leaks

### 3) Added dependency and required test formatting updates
Updated:
- `go.mod` / `go.sum`
- `internal/daemon/runtime/service_launchd_test.go`

### 4) Tests
Leak-aware test runs were added for targeted daemon packages.

## Why This Is Needed
This is a test reliability improvement for concurrency-heavy code.
Automatic leak detection catches lifecycle regressions before merge.

## Behavior Notes / Regression Impact
No runtime feature behavior change.
Only test harness strictness is increased.

## Validation Performed
- `go test ./internal/daemon/controller -count=1`
- `go test ./internal/daemon/server -count=1`
- `go test ./internal/daemon/runtime -count=1`
- `go test ./...`
- `golangci-lint run`
