### PR TITLE
ci(depguard): enforce architecture boundaries in lint and CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ linters:
   # Only enable linters that pass with current codebase
   # Additional linters can be enabled incrementally
   enable:
+    - depguard
     - gocritic
     - gosec
     - misspell
@@ -38,6 +39,28 @@ linters:
         - fieldalignment
         - shadow
       enable-all: true
+    depguard:
+      rules:
+        application-boundaries:
+          files:
+            - internal/application/**/*.go
+          deny:
+            - pkg: github.com/altuslabsxyz/devnet-builder/internal/infrastructure
+              desc: application layer must not import infrastructure
+            - pkg: github.com/altuslabsxyz/devnet-builder/internal/daemon
+              desc: application layer must not import daemon
+            - pkg: github.com/altuslabsxyz/devnet-builder/internal/plugin
+              desc: application layer must not import plugin
+        application-ports-boundaries:
+          files:
+            - internal/application/ports/**/*.go
+          deny:
+            - pkg: github.com/altuslabsxyz/devnet-builder/internal/infrastructure
+              desc: ports layer must not import infrastructure
+            - pkg: github.com/altuslabsxyz/devnet-builder/internal/daemon
+              desc: ports layer must not import daemon
+            - pkg: github.com/altuslabsxyz/devnet-builder/internal/plugin
+              desc: ports layer must not import plugin
   exclusions:
     generated: lax
     presets:
@@ -63,6 +86,16 @@ linters:
       - linters:
           - errcheck
         text: "Error return value of .*(Run|Wait|Signal|Cleanup|MarkFlagRequired|Save|Sscanf).* is not checked"
+      # Stage depguard rollout by ignoring known pre-existing boundary debt.
+      - linters:
+          - depguard
+        path: internal/application/(devnet/export|devnet/docker_deploy|devnet/provision|service)\.go
+      - linters:
+          - depguard
+        path: internal/application/ports/provisioner\.go
+      - linters:
+          - depguard
+        path: _test\.go
     paths:
       - third_party$
       - builtin$

--- a/docs/architecture-boundaries.md
+++ b/docs/architecture-boundaries.md
@@ -1,0 +1,35 @@
+# Architecture Boundaries
+
+This repository enforces architecture boundaries with `depguard` in `golangci-lint`.
+
+## Enforced Rules
+
+1. `internal/application/**` must not import:
+   - `internal/infrastructure/**`
+   - `internal/daemon/**`
+   - `internal/plugin/**`
+2. `internal/application/ports/**` must not import:
+   - `internal/infrastructure/**`
+   - `internal/daemon/**`
+   - `internal/plugin/**`
+
+## Why
+
+These rules keep dependency direction aligned with clean architecture:
+
+- Application code depends on abstractions, not infrastructure details.
+- Ports remain stable contracts without daemon/plugin coupling.
+- Reviewers get automated boundary checks in CI.
+
+## Existing Debt and Rollout
+
+A small set of known legacy files are temporarily excluded from depguard in `.golangci.yml`.
+New violations outside that allowlist fail CI.
+
+## Remediation Pattern
+
+When depguard fails:
+
+1. Move concrete dependency usage into infrastructure/daemon adapters.
+2. Define or extend a port interface in `internal/application/ports`.
+3. Inject the dependency through constructors (DI) instead of direct imports.


### PR DESCRIPTION
## Enhancement Description
Enforce architecture boundaries in CI with depguard to prevent forbidden dependency directions.

## Summary
This PR adds depguard-based architectural checks and documentation so boundary violations are caught automatically during lint/CI.

Previously, boundary enforcement relied heavily on manual review:
- forbidden imports could regress between reviews
- architecture checks were not consistently automated
- remediation guidance was not centralized

Now lint enforces boundary rules and documents the expected dependency direction.

## What Changed

### 1) Enabled depguard architecture rules
Updated:
- `.golangci.yml`

Rules enforce boundary constraints for application and ports packages.

### 2) Added staged allowlist for known legacy violations
- scoped allowlist keeps rollout practical
- new violations are still blocked by CI

### 3) Added architecture boundary documentation
Added:
- `docs/architecture-boundaries.md`

Documentation includes:
- enforced boundaries
- rationale
- remediation approach

### 4) Tests
Validation is lint/CI-focused for this change.

## Why This Is Needed
This is an architecture governance improvement.
Automated boundary checks reduce review burden and prevent dependency-direction regressions.

## Behavior Notes / Regression Impact
No runtime behavior change.
CI/lint behavior becomes stricter for forbidden imports.

## Validation Performed
- `golangci-lint run --enable-only depguard ./...`
- `go test ./...`
